### PR TITLE
Fix: initializing window properties via infiniframeblazorappbuilder failed

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,8 +30,8 @@
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageVersion Include="TUnit" Version="1.21.24" />
-    <PackageVersion Include="TUnit.Core" Version="1.21.24" />
-    <PackageVersion Include="TUnit.Playwright" Version="1.21.24" />
+    <PackageVersion Include="TUnit" Version="1.24.0" />
+    <PackageVersion Include="TUnit.Core" Version="1.24.0" />
+    <PackageVersion Include="TUnit.Playwright" Version="1.24.0" />
   </ItemGroup>
 </Project>

--- a/InfiniFrame.GitHubActions.Linux.slnf
+++ b/InfiniFrame.GitHubActions.Linux.slnf
@@ -12,7 +12,7 @@
             "tests\\InfiniFrameTests\\InfiniFrameTests.csproj",
             "tests\\InfiniFrameTests.Shared\\InfiniFrameTests.Shared.csproj",
             "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj",
-            "tests\\InfiniFrameTests.Blazor\\InfiniFrameTests.Blazor.csproj"
+            "tests\\InfiniFrameTests.BlazorWebView\\InfiniFrameTests.BlazorWebView.csproj"
         ]
     }
 }

--- a/InfiniFrame.GitHubActions.Linux.slnf
+++ b/InfiniFrame.GitHubActions.Linux.slnf
@@ -11,7 +11,8 @@
             "src\\InfiniFrame.Native\\InfiniFrame.Native.proj",
             "tests\\InfiniFrameTests\\InfiniFrameTests.csproj",
             "tests\\InfiniFrameTests.Shared\\InfiniFrameTests.Shared.csproj",
-            "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj"
+            "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj",
+            "tests\\InfiniFrameTests.Blazor\\InfiniFrameTests.Blazor.csproj"
         ]
     }
 }

--- a/InfiniFrame.GitHubActions.MacOs.slnf
+++ b/InfiniFrame.GitHubActions.MacOs.slnf
@@ -12,7 +12,7 @@
             "tests\\InfiniFrameTests\\InfiniFrameTests.csproj",
             "tests\\InfiniFrameTests.Shared\\InfiniFrameTests.Shared.csproj",
             "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj",
-            "tests\\InfiniFrameTests.Blazor\\InfiniFrameTests.Blazor.csproj"
+            "tests\\InfiniFrameTests.BlazorWebView\\InfiniFrameTests.BlazorWebView.csproj"
         ]
     }
 }

--- a/InfiniFrame.GitHubActions.MacOs.slnf
+++ b/InfiniFrame.GitHubActions.MacOs.slnf
@@ -11,7 +11,8 @@
             "src\\InfiniFrame.Native\\InfiniFrame.Native.proj",
             "tests\\InfiniFrameTests\\InfiniFrameTests.csproj",
             "tests\\InfiniFrameTests.Shared\\InfiniFrameTests.Shared.csproj",
-            "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj"
+            "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj",
+            "tests\\InfiniFrameTests.Blazor\\InfiniFrameTests.Blazor.csproj"
         ]
     }
 }

--- a/InfiniFrame.GitHubActions.Windows.slnf
+++ b/InfiniFrame.GitHubActions.Windows.slnf
@@ -11,7 +11,8 @@
 
             "tests\\InfiniFrameTests\\InfiniFrameTests.csproj",
             "tests\\InfiniFrameTests.Shared\\InfiniFrameTests.Shared.csproj",
-            "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj"
+            "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj",
+            "tests\\InfiniFrameTests.Blazor\\InfiniFrameTests.Blazor.csproj"
         ]
     }
 }

--- a/InfiniFrame.GitHubActions.Windows.slnf
+++ b/InfiniFrame.GitHubActions.Windows.slnf
@@ -12,7 +12,7 @@
             "tests\\InfiniFrameTests\\InfiniFrameTests.csproj",
             "tests\\InfiniFrameTests.Shared\\InfiniFrameTests.Shared.csproj",
             "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj",
-            "tests\\InfiniFrameTests.Blazor\\InfiniFrameTests.Blazor.csproj"
+            "tests\\InfiniFrameTests.BlazorWebView\\InfiniFrameTests.BlazorWebView.csproj"
         ]
     }
 }

--- a/InfiniFrame.GitHubActions.slnf
+++ b/InfiniFrame.GitHubActions.slnf
@@ -13,7 +13,7 @@
             "tests\\InfiniFrameTests.Playwright\\InfiniFrameTests.Playwright.csproj",
             "tests\\InfiniFrameTests.Shared\\InfiniFrameTests.Shared.csproj",
             "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj",
-            "tests\\InfiniFrameTests.Blazor\\InfiniFrameTests.Blazor.csproj"
+            "tests\\InfiniFrameTests.BlazorWebView\\InfiniFrameTests.BlazorWebView.csproj"
         ]
     }
 }

--- a/InfiniFrame.GitHubActions.slnf
+++ b/InfiniFrame.GitHubActions.slnf
@@ -12,7 +12,8 @@
             "tests\\InfiniFrameTests\\InfiniFrameTests.csproj",
             "tests\\InfiniFrameTests.Playwright\\InfiniFrameTests.Playwright.csproj",
             "tests\\InfiniFrameTests.Shared\\InfiniFrameTests.Shared.csproj",
-            "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj"
+            "tests\\InfiniFrameTests.WebServer\\InfiniFrameTests.WebServer.csproj",
+            "tests\\InfiniFrameTests.Blazor\\InfiniFrameTests.Blazor.csproj"
         ]
     }
 }

--- a/InfiniFrame.slnx
+++ b/InfiniFrame.slnx
@@ -79,7 +79,7 @@
   <Folder Name="/tests/">
     <File Path="tests/Directory.Build.props" />
     <File Path="tests/Directory.Build.targets" />
-    <Project Path="tests/InfiniFrameTests.Blazor/InfiniFrameTests.Blazor.csproj" />
+    <Project Path="tests/InfiniFrameTests.BlazorWebView/InfiniFrameTests.BlazorWebView.csproj" />
     <Project Path="tests/InfiniFrameTests.Playwright/InfiniFrameTests.Playwright.csproj" />
     <Project Path="tests/InfiniFrameTests.Shared/InfiniFrameTests.Shared.csproj" />
     <Project Path="tests/InfiniFrameTests.WebServer/InfiniFrameTests.WebServer.csproj" />

--- a/InfiniFrame.slnx
+++ b/InfiniFrame.slnx
@@ -79,6 +79,7 @@
   <Folder Name="/tests/">
     <File Path="tests/Directory.Build.props" />
     <File Path="tests/Directory.Build.targets" />
+    <Project Path="tests/InfiniFrameTests.Blazor/InfiniFrameTests.Blazor.csproj" />
     <Project Path="tests/InfiniFrameTests.Playwright/InfiniFrameTests.Playwright.csproj" />
     <Project Path="tests/InfiniFrameTests.Shared/InfiniFrameTests.Shared.csproj" />
     <Project Path="tests/InfiniFrameTests.WebServer/InfiniFrameTests.WebServer.csproj" />

--- a/src/InfiniFrame.BlazorWebView/InfiniFrameBlazorApp.cs
+++ b/src/InfiniFrame.BlazorWebView/InfiniFrameBlazorApp.cs
@@ -14,17 +14,23 @@ public class InfiniFrameBlazorApp(
     RootComponentList rootComponents,
     IInfiniFrameJsComponentConfiguration? rootComponentConfiguration = null
 ) : IAsyncDisposable {
+    public IServiceProvider ServiceProvider { get; }= provider;
+    private RootComponentList RootComponents { get; }= rootComponents;
+    private IInfiniFrameJsComponentConfiguration? RootComponentConfiguration { get; }= rootComponentConfiguration;
 
     private bool _disposed;
 
+    // -----------------------------------------------------------------------------------------------------------------
+    // Methods
+    // -----------------------------------------------------------------------------------------------------------------
     public void Run() {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        var window = provider.GetRequiredService<IInfiniFrameWindow>();
+        var window = ServiceProvider.GetRequiredService<IInfiniFrameWindow>();
 
-        if (rootComponentConfiguration is not null) {
-            foreach ((Type, string) component in rootComponents) {
-                rootComponentConfiguration.Add(component.Item1, component.Item2);
+        if (RootComponentConfiguration is not null) {
+            foreach ((Type, string) component in RootComponents) {
+                RootComponentConfiguration.Add(component.Item1, component.Item2);
             }
         }
 
@@ -43,7 +49,7 @@ public class InfiniFrameBlazorApp(
         _disposed = true;
 
         try {
-            switch (provider) {
+            switch (ServiceProvider) {
                 case ServiceProvider serviceProvider: {
                     await serviceProvider.DisposeAsync();
                     break;
@@ -61,7 +67,7 @@ public class InfiniFrameBlazorApp(
             }
         }
         catch (Exception e) {
-            var logger = provider.GetService<ILogger<InfiniFrameBlazorApp>>();
+            var logger = ServiceProvider.GetService<ILogger<InfiniFrameBlazorApp>>();
             logger?.LogError(e, "Error disposing of InfiniFrameBlazorApp");
         }
 

--- a/src/InfiniFrame.BlazorWebView/InfiniFrameBlazorAppBuilder.cs
+++ b/src/InfiniFrame.BlazorWebView/InfiniFrameBlazorAppBuilder.cs
@@ -29,7 +29,7 @@ public class InfiniFrameBlazorAppBuilder {
         appBuilder.Services.AddOptions<InfiniFrameBlazorAppConfiguration>();
 
         appBuilder.Services
-            .AddSingleton(fileProvider ?? new PhysicalFileProvider(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot")))
+            .AddSingleton(ConfigureFileProvider(fileProvider))
             .AddScoped(static sp => {
                 var handler = sp.GetRequiredService<InfiniFrameHttpHandler>();
                 return new HttpClient(handler) { BaseAddress = new Uri(InfiniFrameWebViewManager.AppBaseUri) };
@@ -47,7 +47,29 @@ public class InfiniFrameBlazorAppBuilder {
             .AddSingleton(appBuilder.WindowBuilder)
             .AddSingleton(appBuilder.RootComponents);
 
+        windowBuilder?.Invoke(appBuilder.WindowBuilder);
+
         return appBuilder;
+    }
+
+    /// <summary>
+    /// Configures the file provider to be used by the application.
+    /// If a custom <see cref="IFileProvider"/> is provided, that instance will be used.
+    /// Otherwise, a default provider will be configured based on the application's "wwwroot" directory.
+    /// </summary>
+    /// <param name="fileProvider">
+    /// An optional <see cref="IFileProvider"/> instance.
+    /// </param>
+    /// <returns>
+    /// An instance of <see cref="IFileProvider"/> that represents either the specified file provider
+    /// or the default provider if none is supplied.
+    /// </returns>
+    private static IFileProvider ConfigureFileProvider(IFileProvider? fileProvider) {
+        if (fileProvider is not null) return fileProvider;
+
+        string defaultWwwrootPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "wwwroot");
+        if (!Directory.Exists(defaultWwwrootPath)) return new NullFileProvider();
+        return new PhysicalFileProvider(defaultWwwrootPath);
     }
 
     public InfiniFrameBlazorAppBuilder WithInfiniFrameWindowBuilder(Action<IInfiniFrameWindowBuilder> windowBuilder) {

--- a/src/InfiniFrame.BlazorWebView/InfiniFrameBlazorAppBuilder.cs
+++ b/src/InfiniFrame.BlazorWebView/InfiniFrameBlazorAppBuilder.cs
@@ -17,9 +17,16 @@ public class InfiniFrameBlazorAppBuilder {
     public IServiceCollection Services { get; } = new ServiceCollection();
     public IInfiniFrameWindowBuilder WindowBuilder { get; } = InfiniFrameWindowBuilder.Create();
 
+    // -----------------------------------------------------------------------------------------------------------------
+    // Constructors
+    // -----------------------------------------------------------------------------------------------------------------
     private InfiniFrameBlazorAppBuilder() {}
 
-    public static InfiniFrameBlazorAppBuilder CreateDefault(string[]? args = null, Action<IInfiniFrameWindowBuilder>? windowBuilder = null) => CreateDefault(null, args, windowBuilder);
+    public static InfiniFrameBlazorAppBuilder CreateDefault(
+        string[]? args = null,
+        Action<IInfiniFrameWindowBuilder>? windowBuilder = null
+    ) 
+        => CreateDefault(null, args, windowBuilder);
 
     public static InfiniFrameBlazorAppBuilder CreateDefault(IFileProvider? fileProvider, string[]? args = null, Action<IInfiniFrameWindowBuilder>? windowBuilder = null) {
         // We don't use the args for anything right now, but we want to accept them

--- a/tests/InfiniFrameTests.Blazor/InfiniFrameTests.Blazor.csproj
+++ b/tests/InfiniFrameTests.Blazor/InfiniFrameTests.Blazor.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <ApplicationIcon>../../assets/favicon.ico</ApplicationIcon>
+        <EnableNativeDllCopy>true</EnableNativeDllCopy>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="TUnit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\InfiniFrame.Blazor\InfiniFrame.Blazor.csproj" />
+        <ProjectReference Include="..\..\src\InfiniFrame\InfiniFrame.csproj" />
+        <ProjectReference Include="..\..\src\InfiniFrame.Shared\InfiniFrame.Shared.csproj" />
+        <ProjectReference Include="..\InfiniFrameTests.Shared\InfiniFrameTests.Shared.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="..\..\assets\favicon.ico">
+            <Link>Assets\favicon.ico</Link>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+</Project>

--- a/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
+++ b/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
@@ -99,7 +99,8 @@ public class InfiniFrameBlazorAppBuilderTests {
     [Test]
     [NotInParallel(ParallelControl.InfiniFrame)]
     [Timeout(TimeoutUtility.DefaultTimeout)]
-    [SkipUtility.SkipOnMacOs]
+    [SkipUtility.SkipOnMacOs("Given init parameters are not supported on macOS")]
+    [SkipUtility.SkipOnLinux("Given init parameters are not supported on Linux")]
     public async Task SetBrowserControlInitParameters_ThroughAppBuilder_ShouldWorkOnWindow(CancellationToken ct) {
         // Arrange
         string[] args = Array.Empty<string>();

--- a/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
+++ b/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
@@ -4,6 +4,7 @@
 using InfiniFrame;
 using InfiniFrame.BlazorWebView;
 using InfiniFrameTests.Shared;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace InfiniFrameTests.BlazorWebView;
 
@@ -20,9 +21,16 @@ public class InfiniFrameBlazorAppBuilderTests {
         const string initParameters = "--force-device-scale-factor=1";
         
         // Act
-        var appbuilder = InfiniFrameBlazorAppBuilder.CreateDefault(args, builder => {
-            builder.SetBrowserControlInitParameters(initParameters);
-        });
+        var appbuilder = InfiniFrameBlazorAppBuilder.CreateDefault(args, builder => builder
+            .SetTitle("Test")
+            .SetBrowserControlInitParameters(initParameters)
+            .SetLeft(0)
+            .SetTop(0)
+            .SetSize(100, 100)
+            .SetResizable(false)
+            .SetChromeless(true)
+            .SetSmoothScrollingEnabled(false)
+        );
         
         // Assert
         await Assert.That(appbuilder).IsNotNull();
@@ -41,11 +49,80 @@ public class InfiniFrameBlazorAppBuilderTests {
         
         // Act
         var appbuilder = InfiniFrameBlazorAppBuilder.CreateDefault(args);
-        appbuilder.WindowBuilder.SetBrowserControlInitParameters(initParameters);
+        appbuilder.WindowBuilder
+            .SetTitle("Test")
+            .SetBrowserControlInitParameters(initParameters)
+            .SetLeft(0)
+            .SetTop(0)
+            .SetSize(100, 100)
+            .SetResizable(false)
+            .SetChromeless(true)
+            .SetSmoothScrollingEnabled(false);
         
         // Assert
         await Assert.That(appbuilder).IsNotNull();
         await Assert.That(appbuilder.WindowBuilder.Configuration.BrowserControlInitParameters).IsEqualTo(
+            initParameters
+        );
+    }
+    
+    [Test]
+    [NotInParallel(ParallelControl.InfiniFrame)]
+    [Timeout(TimeoutUtility.DefaultTimeout)]
+    public async Task SetBrowserControlInitParameters_ThroughCreateDefault_ShouldWorkOnWindow(CancellationToken ct) {
+        // Arrange
+        string[] args = Array.Empty<string>();
+        const string initParameters = "--force-device-scale-factor=1";
+        
+        // Act
+        var appbuilder = InfiniFrameBlazorAppBuilder.CreateDefault(args, builder => builder
+            .SetTitle("Test")
+            .SetBrowserControlInitParameters(initParameters)
+            .SetLeft(0)
+            .SetTop(0)
+            .SetSize(100, 100)
+            .SetResizable(false)
+            .SetChromeless(true)
+            .SetSmoothScrollingEnabled(false)
+        );
+
+        InfiniFrameBlazorApp app = appbuilder.Build();
+        var window = app.ServiceProvider.GetRequiredService<IInfiniFrameWindow>();
+        
+        // Assert
+        await Assert.That(window).IsNotNull();
+        await Assert.That(window.BrowserControlInitParameters).IsEqualTo(
+            initParameters
+        );
+    }
+    
+    [Test]
+    [NotInParallel(ParallelControl.InfiniFrame)]
+    [Timeout(TimeoutUtility.DefaultTimeout)]
+    [SkipUtility.SkipOnMacOs]
+    public async Task SetBrowserControlInitParameters_ThroughAppBuilder_ShouldWorkOnWindow(CancellationToken ct) {
+        // Arrange
+        string[] args = Array.Empty<string>();
+        const string initParameters = "--force-device-scale-factor=1";
+        
+        // Act
+        var appbuilder = InfiniFrameBlazorAppBuilder.CreateDefault(args);
+        appbuilder.WindowBuilder
+            .SetTitle("Test")
+            .SetBrowserControlInitParameters(initParameters)
+            .SetLeft(0)
+            .SetTop(0)
+            .SetSize(100, 100)
+            .SetResizable(false)
+            .SetChromeless(true)
+            .SetSmoothScrollingEnabled(false);
+
+        InfiniFrameBlazorApp app = appbuilder.Build();
+        var window = app.ServiceProvider.GetRequiredService<IInfiniFrameWindow>();
+        
+        // Assert
+        await Assert.That(window).IsNotNull();
+        await Assert.That(window.BrowserControlInitParameters).IsEqualTo(
             initParameters
         );
     }

--- a/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
+++ b/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
@@ -22,7 +22,6 @@ public class InfiniFrameBlazorAppBuilderTests {
         // Act
         var appbuilder = InfiniFrameBlazorAppBuilder.CreateDefault(args, builder => {
             builder.SetBrowserControlInitParameters(initParameters);
-            
         });
         
         // Assert

--- a/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
+++ b/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
@@ -1,0 +1,55 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------------------------------------------------
+using InfiniFrame;
+using InfiniFrame.BlazorWebView;
+using InfiniFrameTests.Shared;
+
+namespace InfiniFrameTests.BlazorWebView;
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Code
+// ---------------------------------------------------------------------------------------------------------------------
+public class InfiniFrameBlazorAppBuilderTests {
+    [Test]
+    [DisplayName($"{nameof(InfiniFrameBlazorAppBuilderTests)}.{nameof(SetBrowserControlInitParameters_ThroughCreateDefault_ShouldWork)}")]
+    [NotInParallel(ParallelControl.InfiniFrame)]
+    [Timeout(TimeoutUtility.DefaultTimeout)]
+    public async Task SetBrowserControlInitParameters_ThroughCreateDefault_ShouldWork(CancellationToken ct) {
+        // Arrange
+        string[] args = Array.Empty<string>();
+        const string initParameters = "--force-device-scale-factor=1";
+        
+        // Act
+        var appbuilder = InfiniFrameBlazorAppBuilder.CreateDefault(args, builder => {
+            builder.SetBrowserControlInitParameters(initParameters);
+            
+        });
+        
+        // Assert
+        await Assert.That(appbuilder).IsNotNull();
+        await Assert.That(appbuilder.WindowBuilder.Configuration.BrowserControlInitParameters).IsEqualTo(
+            initParameters
+        );
+    }
+    
+    [Test]
+    [DisplayName($"{nameof(InfiniFrameBlazorAppBuilderTests)}.{nameof(SetBrowserControlInitParameters_ThroughCreateDefault_ShouldWork)}")]
+    [NotInParallel(ParallelControl.InfiniFrame)]
+    [Timeout(TimeoutUtility.DefaultTimeout)]
+    public async Task SetBrowserControlInitParameters_ThroughAppBuilder_ShouldWork(CancellationToken ct) {
+        // Arrange
+        string[] args = Array.Empty<string>();
+        const string initParameters = "--force-device-scale-factor=1";
+        
+        // Act
+        var appbuilder = InfiniFrameBlazorAppBuilder.CreateDefault(args);
+        appbuilder.WindowBuilder.SetBrowserControlInitParameters(initParameters);
+        
+        // Assert
+        await Assert.That(appbuilder).IsNotNull();
+        await Assert.That(appbuilder.WindowBuilder.Configuration.BrowserControlInitParameters).IsEqualTo(
+            initParameters
+        );
+    }
+}

--- a/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
+++ b/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
@@ -12,7 +12,6 @@ namespace InfiniFrameTests.BlazorWebView;
 // ---------------------------------------------------------------------------------------------------------------------
 public class InfiniFrameBlazorAppBuilderTests {
     [Test]
-    [DisplayName($"{nameof(InfiniFrameBlazorAppBuilderTests)}.{nameof(SetBrowserControlInitParameters_ThroughCreateDefault_ShouldWork)}")]
     [NotInParallel(ParallelControl.InfiniFrame)]
     [Timeout(TimeoutUtility.DefaultTimeout)]
     public async Task SetBrowserControlInitParameters_ThroughCreateDefault_ShouldWork(CancellationToken ct) {
@@ -34,7 +33,6 @@ public class InfiniFrameBlazorAppBuilderTests {
     }
     
     [Test]
-    [DisplayName($"{nameof(InfiniFrameBlazorAppBuilderTests)}.{nameof(SetBrowserControlInitParameters_ThroughCreateDefault_ShouldWork)}")]
     [NotInParallel(ParallelControl.InfiniFrame)]
     [Timeout(TimeoutUtility.DefaultTimeout)]
     public async Task SetBrowserControlInitParameters_ThroughAppBuilder_ShouldWork(CancellationToken ct) {

--- a/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
+++ b/tests/InfiniFrameTests.BlazorWebView/InfiniFrameBlazorAppBuilderTests.cs
@@ -69,6 +69,8 @@ public class InfiniFrameBlazorAppBuilderTests {
     [Test]
     [NotInParallel(ParallelControl.InfiniFrame)]
     [Timeout(TimeoutUtility.DefaultTimeout)]
+    [SkipUtility.SkipOnMacOs("Given init parameters are not supported on macOS")]
+    [SkipUtility.SkipOnLinux("Given init parameters are not supported on Linux")]
     public async Task SetBrowserControlInitParameters_ThroughCreateDefault_ShouldWorkOnWindow(CancellationToken ct) {
         // Arrange
         string[] args = Array.Empty<string>();

--- a/tests/InfiniFrameTests.BlazorWebView/InfiniFrameTests.BlazorWebView.csproj
+++ b/tests/InfiniFrameTests.BlazorWebView/InfiniFrameTests.BlazorWebView.csproj
@@ -10,6 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\src\InfiniFrame.BlazorWebView\InfiniFrame.BlazorWebView.csproj" />
         <ProjectReference Include="..\..\src\InfiniFrame.Blazor\InfiniFrame.Blazor.csproj" />
         <ProjectReference Include="..\..\src\InfiniFrame\InfiniFrame.csproj" />
         <ProjectReference Include="..\..\src\InfiniFrame.Shared\InfiniFrame.Shared.csproj" />


### PR DESCRIPTION
## Description
Fixes `InfiniFrameBlazorAppBuilder.CreateDefault(...)` so window builder configuration callbacks are actually applied, including browser init parameters, and hardens default file-provider behavior when `wwwroot` is missing.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made
- Fixed `CreateDefault(..., windowBuilder)` to invoke the provided window builder action, so settings like `SetBrowserControlInitParameters(...)` are honored.
- Extracted file provider setup into `ConfigureFileProvider(...)` and now falls back to `NullFileProvider` when default `wwwroot` is absent.
- Refactored `InfiniFrameBlazorApp` to expose `ServiceProvider` and use internal properties consistently.
- Added new `InfiniFrameTests.BlazorWebView` test project and added it to solution/CI solution filters.
- Added tests covering browser init parameters via both `CreateDefault` callback and direct app-builder configuration (including window-level assertions).
- Bumped TUnit packages from `1.21.24` to `1.24.0`.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [x] All tests pass locally
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published