### PR TITLE
Fix: Handle window size in native layer

### DIFF
--- a/src/InfiniFrame.Native/Core/InfiniFrameWindow.h
+++ b/src/InfiniFrame.Native/Core/InfiniFrameWindow.h
@@ -206,6 +206,20 @@ public:
     void GetSize(int *width, int *height) const;
 
     /**
+     * @brief Get the maximum allowed window size
+     * @param width  Output: maximum width in pixels
+     * @param height Output: maximum height in pixels
+     */
+    void GetMaxSize(int *width, int *height) const;
+
+    /**
+     * @brief Get the minimum allowed window size
+     * @param width  Output: minimum width in pixels
+     * @param height Output: minimum height in pixels
+     */
+    void GetMinSize(int *width, int *height) const;
+
+    /**
      * @brief Get the window title bar text
      * @return UTF-8 title string; caller must free with InfiniFrame_FreeString
      */

--- a/src/InfiniFrame.Native/Exports.cpp
+++ b/src/InfiniFrame.Native/Exports.cpp
@@ -327,6 +327,28 @@ extern "C"
 	}
 
 	/**
+	 * @brief Get the window maximum size constraints
+	 * @param instance InfiniFrame instance
+	 * @param width Output: maximum window width
+	 * @param height Output: maximum window height
+	 */
+	EXPORTED void InfiniFrame_GetMaxSize(InfiniFrameWindow *instance, int *width, int *height)
+	{
+		instance->GetMaxSize(width, height);
+	}
+
+	/**
+	 * @brief Get the window minimum size constraints
+	 * @param instance InfiniFrame instance
+	 * @param width Output: minimum window width
+	 * @param height Output: minimum window height
+	 */
+	EXPORTED void InfiniFrame_GetMinSize(InfiniFrameWindow *instance, int *width, int *height)
+	{
+		instance->GetMinSize(width, height);
+	}
+
+	/**
 	 * @brief Get window title
 	 * @param instance InfiniFrame instance
 	 * @return Window title string

--- a/src/InfiniFrame.Native/Platform/Linux/Window.cpp
+++ b/src/InfiniFrame.Native/Platform/Linux/Window.cpp
@@ -629,6 +629,18 @@ void InfiniFrameWindow::GetSize(int *width, int *height) const
 	gtk_window_get_size(GTK_WINDOW(m_impl->_window), width, height);
 }
 
+void InfiniFrameWindow::GetMaxSize(int *width, int *height) const
+{
+	if (width) *width = m_impl->_maxWidth;
+	if (height) *height = m_impl->_maxHeight;
+}
+
+void InfiniFrameWindow::GetMinSize(int *width, int *height) const
+{
+	if (width) *width = m_impl->_minWidth;
+	if (height) *height = m_impl->_minHeight;
+}
+
 AutoString InfiniFrameWindow::GetTitle() const
 {
 	return const_cast<AutoString>(gtk_window_get_title(GTK_WINDOW(m_impl->_window)));
@@ -773,6 +785,8 @@ void InfiniFrameWindow::SetResizable(const bool resizable)
 
 void InfiniFrameWindow::SetMinSize(const int width, const int height)
 {
+	m_impl->_minWidth = width;
+	m_impl->_minHeight = height;
 	m_impl->_hints.min_width = width;
 	m_impl->_hints.min_height = height;
 
@@ -785,6 +799,8 @@ void InfiniFrameWindow::SetMinSize(const int width, const int height)
 
 void InfiniFrameWindow::SetMaxSize(const int width, const int height)
 {
+	m_impl->_maxWidth = width;
+	m_impl->_maxHeight = height;
 	m_impl->_hints.max_width = width;
 	m_impl->_hints.max_height = height;
 

--- a/src/InfiniFrame.Native/Platform/Mac/Window.mm
+++ b/src/InfiniFrame.Native/Platform/Mac/Window.mm
@@ -530,6 +530,20 @@ void InfiniFrameWindow::GetSize(int* width, int* height) const
     if (height) *height = static_cast<int>(roundf(size.height));
 }
 
+void InfiniFrameWindow::GetMaxSize(int* width, int* height) const
+{
+    NSSize maxSize = [m_impl->_window maxSize];
+    if (width) *width = static_cast<int>(roundf(maxSize.width));
+    if (height) *height = static_cast<int>(roundf(maxSize.height));
+}
+
+void InfiniFrameWindow::GetMinSize(int* width, int* height) const
+{
+    NSSize minSize = [m_impl->_window minSize];
+    if (width) *width = static_cast<int>(roundf(minSize.width));
+    if (height) *height = static_cast<int>(roundf(minSize.height));
+}
+
 AutoString InfiniFrameWindow::GetTitle() const
 {
     return const_cast<AutoString>(m_impl->_windowTitle.c_str());

--- a/src/InfiniFrame.Native/Platform/Windows/Window.cpp
+++ b/src/InfiniFrame.Native/Platform/Windows/Window.cpp
@@ -763,6 +763,18 @@ void InfiniFrameWindow::GetSize(int* width, int* height) const
 	if (height) *height = rect.bottom - rect.top;
 }
 
+void InfiniFrameWindow::GetMaxSize(int* width, int* height) const
+{
+	if (width) *width = m_impl->_maxWidth;
+	if (height) *height = m_impl->_maxHeight;
+}
+
+void InfiniFrameWindow::GetMinSize(int* width, int* height) const
+{
+	if (width) *width = m_impl->_minWidth;
+	if (height) *height = m_impl->_minHeight;
+}
+
 AutoString InfiniFrameWindow::GetTitle() const
 {
 	return const_cast<AutoString>(m_impl->_windowTitle.c_str());

--- a/src/InfiniFrame.Shared/FluentApi/InfiniWindowExtensions.cs
+++ b/src/InfiniFrame.Shared/FluentApi/InfiniWindowExtensions.cs
@@ -632,10 +632,6 @@ public static class InfiniWindowExtensions {
         /// </returns>
         public T SetMaxSize(int maxWidth, int maxHeight) {
             window.Logger.LogDebug(".SetMaxSize({MaxWidth}, {MaxHeight})", maxWidth, maxHeight);
-
-            window.MaxWidth = maxWidth;
-            window.MaxHeight = maxHeight;
-
             window.Invoke(() => InfiniFrameNative.SetMaxSize(window.InstanceHandle, maxWidth, maxHeight));
             return window;
         }
@@ -694,10 +690,6 @@ public static class InfiniWindowExtensions {
         /// </returns>
         public T SetMinSize(int minWidth, int minHeight) {
             window.Logger.LogDebug(".SetMinSize({MinWidth}, {MinHeight})", minWidth, minHeight);
-
-            window.MinHeight = minHeight;
-            window.MinWidth = minWidth;
-
             window.Invoke(() => InfiniFrameNative.SetMinSize(window.InstanceHandle, minWidth, minHeight));
             return window;
         }

--- a/src/InfiniFrame.Shared/IHasInfiniFrameProperties.cs
+++ b/src/InfiniFrame.Shared/IHasInfiniFrameProperties.cs
@@ -24,10 +24,10 @@ public interface IHasInfiniFrameProperties {
     int Left { get; }
     int Top { get; }
     bool Maximized { get; }
-    int MaxWidth { get; set; }
-    int MaxHeight { get; set; }
-    int MinWidth { get; set; }
-    int MinHeight { get; set; }
+    int MaxWidth { get; }
+    int MaxHeight { get; }
+    int MinWidth { get; }
+    int MinHeight { get; }
     bool Minimized { get; }
     bool Resizable { get; }
     int Width { get; }

--- a/src/InfiniFrame.Shared/IInfiniFrameWindow.cs
+++ b/src/InfiniFrame.Shared/IInfiniFrameWindow.cs
@@ -22,8 +22,8 @@ public interface IInfiniFrameWindow : IHasInfiniFrameProperties, IHasInfiniFrame
     uint ScreenDpi { get; }
     Guid Id { get; }
     Point Location { get; }
-    Size MaxSize { get; set; }
-    Size MinSize { get; set; }
+    Size MaxSize { get; }
+    Size MinSize { get; }
     Size Size { get; }
     IInfiniFrameWindow? Parent { get; }
     int ManagedThreadId { get; }

--- a/src/InfiniFrame.Shared/Native/InfiniFrameNative.cs
+++ b/src/InfiniFrame.Shared/Native/InfiniFrameNative.cs
@@ -100,6 +100,12 @@ public static partial class InfiniFrameNative {
     [LibraryImport(DllName, EntryPoint = InfiniFrame_GetSize, SetLastError = true), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void GetSize(IntPtr instance, out int width, out int height);
 
+    [LibraryImport(DllName, EntryPoint = InfiniFrame_GetMaxSize, SetLastError = true), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void GetMaxSize(IntPtr instance, out int maxWidth, out int maxHeight);
+
+    [LibraryImport(DllName, EntryPoint = InfiniFrame_GetMinSize, SetLastError = true), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void GetMinSize(IntPtr instance, out int minWidth, out int minHeight);
+
     [LibraryImport(DllName, EntryPoint = InfiniFrame_GetTitle, SetLastError = true), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial IntPtr GetTitle(IntPtr instance);
 
@@ -245,12 +251,26 @@ public static partial class InfiniFrameNative {
 
     internal static void GetHeight(IntPtr instance, out int height) => GetSize(instance, out _, out height);
     internal static void GetWidth(IntPtr instance, out int width) => GetSize(instance, out width, out _);
+    internal static void GetMaxHeight(IntPtr instance, out int maxHeight) => GetMaxSize(instance, out _, out maxHeight);
+    internal static void GetMaxWidth(IntPtr instance, out int maxWidth) => GetMaxSize(instance, out maxWidth, out _);
+    internal static void GetMinHeight(IntPtr instance, out int minHeight) => GetMinSize(instance, out _, out minHeight);
+    internal static void GetMinWidth(IntPtr instance, out int minWidth) => GetMinSize(instance, out minWidth, out _);
 
     internal static void GetLeft(IntPtr instance, out int left) => GetPosition(instance, out left, out _);
     internal static void GetTop(IntPtr instance, out int top) => GetPosition(instance, out _, out top);
 
     internal static void GetSize(IntPtr instance, out Size size) {
         GetSize(instance, out int width, out int height);
+        size = new Size(width, height);
+    }
+
+    internal static void GetMaxSize(IntPtr instance, out Size size) {
+        GetMaxSize(instance, out int width, out int height);
+        size = new Size(width, height);
+    }
+
+    internal static void GetMinSize(IntPtr instance, out Size size) {
+        GetMinSize(instance, out int width, out int height);
         size = new Size(width, height);
     }
 

--- a/src/InfiniFrame.Shared/Native/NativeDll.cs
+++ b/src/InfiniFrame.Shared/Native/NativeDll.cs
@@ -36,6 +36,8 @@ internal static class NativeDll {
     internal const string InfiniFrame_GetResizable = nameof(InfiniFrame_GetResizable);
     internal const string InfiniFrame_GetScreenDpi = nameof(InfiniFrame_GetScreenDpi);
     internal const string InfiniFrame_GetSize = nameof(InfiniFrame_GetSize);
+    internal const string InfiniFrame_GetMaxSize = nameof(InfiniFrame_GetMaxSize);
+    internal const string InfiniFrame_GetMinSize = nameof(InfiniFrame_GetMinSize);
     internal const string InfiniFrame_GetTitle = nameof(InfiniFrame_GetTitle);
     internal const string InfiniFrame_GetTopmost = nameof(InfiniFrame_GetTopmost);
     internal const string InfiniFrame_GetZoom = nameof(InfiniFrame_GetZoom);

--- a/src/InfiniFrame/InfiniFrameWindow.cs
+++ b/src/InfiniFrame/InfiniFrameWindow.cs
@@ -633,98 +633,48 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool Focused => InvokeUtilities.InvokeAndReturn<bool>(this, InfiniFrameNative.GetFocused);
 
-    ///<summary>Gets or set the maximum size of the native window in pixels.</summary>
-    public Size MaxSize {
-        get => InstanceHandle == IntPtr.Zero
-            ? new Size(StartupParameters.MaxWidth, StartupParameters.MaxHeight)
-            : InvokeUtilities.InvokeAndReturn<Size>(this, InfiniFrameNative.GetMaxSize);
-        set {
-            MaxWidth = value.Width;
-            MaxHeight = value.Height;
-        }
-    }
-
-    ///<summary>Gets or sets the native window maximum height in pixels.</summary>
+    /// <summary>
+    ///     Gets or set the maximum size of the native window in pixels.
+    /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    public int MaxHeight {
-        get => InstanceHandle == IntPtr.Zero
-            ? StartupParameters.MaxHeight
-            : InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMaxHeight);
-        set {
-            if (InstanceHandle == IntPtr.Zero) {
-                StartupParameters.MaxHeight = value;
-                return;
-            }
-
-            Invoke(() => InfiniFrameNative.SetMaxSize(InstanceHandle, MaxWidth, value));
-        }
-    }
-
-    ///<summary>Gets or sets the native window maximum width in pixels.</summary>
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    public int MaxWidth {
-        get => InstanceHandle == IntPtr.Zero
-            ? StartupParameters.MaxWidth
-            : InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMaxWidth);
-        set {
-            if (InstanceHandle == IntPtr.Zero) {
-                StartupParameters.MaxWidth = value;
-                return;
-            }
-
-            Invoke(() => InfiniFrameNative.SetMaxSize(InstanceHandle, value, MaxHeight));
-        }
-    }
+    public Size MaxSize => InvokeUtilities.InvokeAndReturn<Size>(this, InfiniFrameNative.GetMaxSize);
 
     /// <summary>
-    ///     Gets or sets whether the native window is minimized (hidden).
+    ///     Gets the native window maximum height in pixels.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public int MaxHeight => InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMaxHeight);
+
+    /// <summary>
+    ///     Gets the native window maximum width in pixels.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public int MaxWidth => InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMaxWidth);
+
+    /// <summary>
+    ///     Gets whether the native window is minimized (hidden).
     ///     Default is false.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool Minimized => InvokeUtilities.InvokeAndReturn<bool>(this, InfiniFrameNative.GetMinimized);
 
-    ///<summary>Gets or set the minimum size of the native window in pixels.</summary>
-    public Size MinSize {
-        get => InstanceHandle == IntPtr.Zero
-            ? new Size(StartupParameters.MinWidth, StartupParameters.MinHeight)
-            : InvokeUtilities.InvokeAndReturn<Size>(this, InfiniFrameNative.GetMinSize);
-        set {
-            MinWidth = value.Width;
-            MinHeight = value.Height;
-        }
-    }
-
-    ///<summary>Gets or sets the native window minimum height in pixels.</summary>
+    /// <summary>
+    ///     Gets or set the minimum size of the native window in pixels.
+    /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    public int MinHeight {
-        get => InstanceHandle == IntPtr.Zero
-            ? StartupParameters.MinHeight
-            : InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMinHeight);
-        set {
-            if (InstanceHandle == IntPtr.Zero) {
-                StartupParameters.MinHeight = value;
-                return;
-            }
+    public Size MinSize => InvokeUtilities.InvokeAndReturn<Size>(this, InfiniFrameNative.GetMinSize);
 
-            Invoke(() => InfiniFrameNative.SetMinSize(InstanceHandle, MinWidth, value));
-        }
-    }
-
-    ///<summary>Gets or sets the native window minimum width in pixels.</summary>
+    /// <summary>
+    ///     Gets or sets the native window minimum height in pixels.
+    /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    public int MinWidth {
-        get => InstanceHandle == IntPtr.Zero
-            ? StartupParameters.MinWidth
-            : InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMinWidth);
-        set {
-            if (InstanceHandle == IntPtr.Zero) {
-                StartupParameters.MinWidth = value;
-                return;
-            }
+    public int MinHeight => InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMinHeight);
 
-            Invoke(() => InfiniFrameNative.SetMinSize(InstanceHandle, value, MinHeight));
-        }
-    }
+    /// <summary>
+    ///     Gets or sets the native window minimum width in pixels.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public int MinWidth => InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMinWidth);
 
     /// <summary>
     ///     Gets or sets whether the user can resize the native window.

--- a/src/InfiniFrame/InfiniFrameWindow.cs
+++ b/src/InfiniFrame/InfiniFrameWindow.cs
@@ -533,7 +533,7 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     /// </exception>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool Transparent => OperatingSystem.IsWindows()
-        ? StartupParameters.Transparent// on windows it can only be set at startup
+        ? StartupParameters.Transparent // on windows it can only be set at startup
         : InvokeUtilities.InvokeAndReturn<bool>(this, InfiniFrameNative.GetTransparentEnabled);
 
     /// <summary>
@@ -593,27 +593,27 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     public bool GrantBrowserPermissions => InvokeUtilities.InvokeAndReturn<bool>(this, InfiniFrameNative.GetGrantBrowserPermissions);
 
     /// <summary>
-    ///     Gets or Sets the Height property of the native window in pixels.
+    ///     Gets the Height property of the native window in pixels.
     ///     The default value is 0.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public int Height => InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetHeight);
 
     /// <summary>
-    ///     Gets or sets the icon file for the native window title bar.
+    ///     Gets the icon file for the native window title bar.
     ///     The file must be located on the local machine and cannot be a URL. The default is none.
     /// </summary>
     public string IconFilePath => InvokeUtilities.InvokeAndReturn<string>(this, InfiniFrameNative.GetIconFileName);
 
     /// <summary>
-    ///     Gets or sets the native window Left (X) and Top coordinates (Y) in pixels.
+    ///     Gets the native window Left (X) and Top coordinates (Y) in pixels.
     ///     Default is 0,0 that means the window will be aligned to the top-left edge of the screen.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public Point Location => InvokeUtilities.InvokeAndReturn<Point>(this, InfiniFrameNative.GetPosition);
 
     /// <summary>
-    ///     Gets or sets the native window Left (X) coordinate in pixels.
+    ///     Gets the native window Left (X) coordinate in pixels.
     ///     This represents the horizontal position of the window relative to the screen.
     ///     The default value is 0, which means the window will be aligned to the left edge of the screen.
     /// </summary>
@@ -621,7 +621,7 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     public int Left => InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetLeft);
 
     /// <summary>
-    ///     Gets or sets whether the native window is maximized.
+    ///     Gets whether the native window is maximized.
     ///     Default is false.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -634,7 +634,7 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     public bool Focused => InvokeUtilities.InvokeAndReturn<bool>(this, InfiniFrameNative.GetFocused);
 
     /// <summary>
-    ///     Gets or set the maximum size of the native window in pixels.
+    ///     Gets the maximum size of the native window in pixels.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public Size MaxSize => InvokeUtilities.InvokeAndReturn<Size>(this, InfiniFrameNative.GetMaxSize);
@@ -653,45 +653,44 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
 
     /// <summary>
     ///     Gets whether the native window is minimized (hidden).
-    ///     Default is false.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool Minimized => InvokeUtilities.InvokeAndReturn<bool>(this, InfiniFrameNative.GetMinimized);
 
     /// <summary>
-    ///     Gets or set the minimum size of the native window in pixels.
+    ///     Gets the minimum size of the native window in pixels.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public Size MinSize => InvokeUtilities.InvokeAndReturn<Size>(this, InfiniFrameNative.GetMinSize);
 
     /// <summary>
-    ///     Gets or sets the native window minimum height in pixels.
+    ///     Gets the native window minimum height in pixels.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public int MinHeight => InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMinHeight);
 
     /// <summary>
-    ///     Gets or sets the native window minimum width in pixels.
+    ///     Gets the native window minimum width in pixels.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public int MinWidth => InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMinWidth);
 
     /// <summary>
-    ///     Gets or sets whether the user can resize the native window.
+    ///     Gets whether the user can resize the native window.
     ///     Default is true.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool Resizable => InvokeUtilities.InvokeAndReturn<bool>(this, InfiniFrameNative.GetResizable);
 
     /// <summary>
-    ///     Gets or sets the native window Size. This represents the width and the height of the window in pixels.
+    ///     Gets the native window Size. This represents the width and the height of the window in pixels.
     ///     The default Size is 0,0.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public Size Size => InvokeUtilities.InvokeAndReturn<Size>(this, InfiniFrameNative.GetSize);
 
     /// <summary>
-    ///     Gets or sets platform-specific initialization parameters for the native browser control on startup.
+    ///     Gets platform-specific initialization parameters for the native browser control on startup.
     ///     Default is none.
     ///     WINDOWS: WebView2 specific string. Space separated.
     ///     https://peter.sh/experiments/chromium-command-line-switches/
@@ -710,7 +709,7 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     public string? BrowserControlInitParameters => StartupParameters.BrowserControlInitParameters;
 
     /// <summary>
-    ///     Gets or sets an HTML string that the browser control will render when initialized.
+    ///     Gets an HTML string that the browser control will render when initialized.
     ///     Default is none.
     /// </summary>
     /// <remarks>
@@ -723,7 +722,7 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     public string? StartString => StartupParameters.StartString;
 
     /// <summary>
-    ///     Gets or sets a URL that the browser control will navigate to when initialized.
+    ///     Gets a URL that the browser control will navigate to when initialized.
     ///     Default is none.
     /// </summary>
     /// <remarks>
@@ -736,7 +735,7 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     public string? StartUrl => StartupParameters.StartUrl;
 
     /// <summary>
-    ///     Gets or sets the local path to store temp files for browser control.
+    ///     Gets the local path to store temp files for browser control.
     ///     Default is the user's AppDataLocal folder.
     /// </summary>
     /// <remarks>
@@ -748,7 +747,7 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     public string? TemporaryFilesPath => StartupParameters.TemporaryFilesPath;
 
     /// <summary>
-    ///     Gets or sets the registration id for doing toast notifications.
+    ///     Gets the registration id for doing toast notifications.
     ///     The default is to use the window title.
     /// </summary>
     /// <remarks>
@@ -760,35 +759,35 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     public string? NotificationRegistrationId => StartupParameters.NotificationRegistrationId;
 
     /// <summary>
-    ///     Gets or sets the native window title.
+    ///     Gets the native window title.
     ///     The default is "InfiniFrame".
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public string Title => InvokeUtilities.InvokeAndReturn<string>(this, InfiniFrameNative.GetTitle);
 
     /// <summary>
-    ///     Gets or sets the native window Top (Y) coordinate in pixels.
+    ///     Gets the native window Top (Y) coordinate in pixels.
     ///     Default is 0.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public int Top => InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetTop);
 
     /// <summary>
-    ///     Gets or sets whether the native window is always at the top of the z-order.
+    ///     Gets whether the native window is always at the top of the z-order.
     ///     Default is false.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool TopMost => InvokeUtilities.InvokeAndReturn<bool>(this, InfiniFrameNative.GetTopmost);
 
     /// <summary>
-    ///     Gets or Sets the native window width in pixels.
+    ///     Gets the native window width in pixels.
     ///     Default is 0.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public int Width => InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetWidth);
 
     /// <summary>
-    ///     Gets or sets the native browser control <see cref="InfiniFrameWindow.Zoom" />.
+    ///     Gets the native browser control <see cref="InfiniFrameWindow.Zoom" />.
     ///     Default is 100.
     /// </summary>
     /// <example>100 = 100%, 50 = 50%</example>

--- a/src/InfiniFrame/InfiniFrameWindow.cs
+++ b/src/InfiniFrame/InfiniFrameWindow.cs
@@ -635,7 +635,9 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
 
     ///<summary>Gets or set the maximum size of the native window in pixels.</summary>
     public Size MaxSize {
-        get => new(MaxWidth, MaxHeight);
+        get => InstanceHandle == IntPtr.Zero
+            ? new Size(StartupParameters.MaxWidth, StartupParameters.MaxHeight)
+            : InvokeUtilities.InvokeAndReturn<Size>(this, InfiniFrameNative.GetMaxSize);
         set {
             MaxWidth = value.Width;
             MaxHeight = value.Height;
@@ -643,10 +645,36 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     }
 
     ///<summary>Gets or sets the native window maximum height in pixels.</summary>
-    public int MaxHeight { get; set; }
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public int MaxHeight {
+        get => InstanceHandle == IntPtr.Zero
+            ? StartupParameters.MaxHeight
+            : InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMaxHeight);
+        set {
+            if (InstanceHandle == IntPtr.Zero) {
+                StartupParameters.MaxHeight = value;
+                return;
+            }
+
+            Invoke(() => InfiniFrameNative.SetMaxSize(InstanceHandle, MaxWidth, value));
+        }
+    }
 
     ///<summary>Gets or sets the native window maximum width in pixels.</summary>
-    public int MaxWidth { get; set; }
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public int MaxWidth {
+        get => InstanceHandle == IntPtr.Zero
+            ? StartupParameters.MaxWidth
+            : InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMaxWidth);
+        set {
+            if (InstanceHandle == IntPtr.Zero) {
+                StartupParameters.MaxWidth = value;
+                return;
+            }
+
+            Invoke(() => InfiniFrameNative.SetMaxSize(InstanceHandle, value, MaxHeight));
+        }
+    }
 
     /// <summary>
     ///     Gets or sets whether the native window is minimized (hidden).
@@ -657,7 +685,9 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
 
     ///<summary>Gets or set the minimum size of the native window in pixels.</summary>
     public Size MinSize {
-        get => new(MinWidth, MinHeight);
+        get => InstanceHandle == IntPtr.Zero
+            ? new Size(StartupParameters.MinWidth, StartupParameters.MinHeight)
+            : InvokeUtilities.InvokeAndReturn<Size>(this, InfiniFrameNative.GetMinSize);
         set {
             MinWidth = value.Width;
             MinHeight = value.Height;
@@ -665,10 +695,36 @@ public sealed class InfiniFrameWindow : IInfiniFrameWindow {
     }
 
     ///<summary>Gets or sets the native window minimum height in pixels.</summary>
-    public int MinHeight { get; set; }
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public int MinHeight {
+        get => InstanceHandle == IntPtr.Zero
+            ? StartupParameters.MinHeight
+            : InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMinHeight);
+        set {
+            if (InstanceHandle == IntPtr.Zero) {
+                StartupParameters.MinHeight = value;
+                return;
+            }
+
+            Invoke(() => InfiniFrameNative.SetMinSize(InstanceHandle, MinWidth, value));
+        }
+    }
 
     ///<summary>Gets or sets the native window minimum width in pixels.</summary>
-    public int MinWidth { get; set; }
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public int MinWidth {
+        get => InstanceHandle == IntPtr.Zero
+            ? StartupParameters.MinWidth
+            : InvokeUtilities.InvokeAndReturn<int>(this, InfiniFrameNative.GetMinWidth);
+        set {
+            if (InstanceHandle == IntPtr.Zero) {
+                StartupParameters.MinWidth = value;
+                return;
+            }
+
+            Invoke(() => InfiniFrameNative.SetMinSize(InstanceHandle, value, MinHeight));
+        }
+    }
 
     /// <summary>
     ///     Gets or sets whether the user can resize the native window.

--- a/src/InfiniFrame/InfiniFrameWindowBuilder.cs
+++ b/src/InfiniFrame/InfiniFrameWindowBuilder.cs
@@ -83,11 +83,6 @@ public class InfiniFrameWindowBuilder : IInfiniFrameWindowBuilder {
         startupParameters.CustomSchemeHandler = window.OnCustomScheme;
         window.StartupParameters = startupParameters;
 
-        window.MaxHeight = startupParameters.MaxHeight;
-        window.MaxWidth = startupParameters.MaxWidth;
-        window.MinHeight = startupParameters.MinHeight;
-        window.MinWidth = startupParameters.MinWidth;
-
         // window.IconFilePath = startupParameters.WindowIconFile;
 
         Events.CompleteSetup(window);


### PR DESCRIPTION
## Description
This PR fixes the window size constraint properties so `MaxHeight`, `MaxWidth`, `MinHeight`, and `MinWidth` are retrieved from the native layer instead of being stored separately in managed C# state

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Changes Made

- Added native `GetMaxSize` and `GetMinSize` APIs and wired them through the export and C# interop layers
- Updated `InfiniFrameWindow` to read min/max size constraints from native state, with startup parameter fallback before initialization
- Removed managed-side caching of min/max window size constraints from the window builder and window extension methods
- Implemented native min/max size getters for Windows, Linux, and macOS, and ensured Linux keeps its internal constraint values in sync when setters are called

## Related Issues
Closes #79

## Checklist

- [x] My code follows the project's coding standards
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] All tests pass locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published