### PR TITLE
Various fixes to resolve code security reports of github actions

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/workflows/shared-testing.yml
         with:
             pr_number: ''
-            checkout_ref: ${{ needs.bump-version.outputs.tag_name }}
+            checkout_ref: ''
             run_windows: true
             run_windows_playwright: false
             run_linux: true

--- a/.github/workflows/ci-testing-python.yml
+++ b/.github/workflows/ci-testing-python.yml
@@ -16,6 +16,9 @@ on:
             - .github/workflows/ci-testing-python.yml
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     # noinspection UndefinedAction
     run:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,6 +1,10 @@
 name: "CI: Platform Tests"
+
 permissions:
     contents: read
+    statuses: write
+    checks: write
+
 on:
     workflow_dispatch:
         inputs:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,4 +1,6 @@
 name: "CI: Platform Tests"
+permissions:
+    contents: read
 on:
     workflow_dispatch:
         inputs:

--- a/.github/workflows/ci-todo.yml
+++ b/.github/workflows/ci-todo.yml
@@ -10,6 +10,9 @@ jobs:
     todo-to-issue:
         name: Sync Todo Issues
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: write
         steps:
             -   name: Checkout
                 uses: actions/checkout@v6

--- a/.github/workflows/shared-release-build.yml
+++ b/.github/workflows/shared-release-build.yml
@@ -7,6 +7,9 @@ on:
                 required: true
                 type: string
 
+permissions:
+    contents: read
+
 jobs:
     build:
         name: Build Native (${{ matrix.os }}/${{ matrix.arch }})

--- a/.github/workflows/shared-release-bump-version.yml
+++ b/.github/workflows/shared-release-bump-version.yml
@@ -23,6 +23,8 @@ jobs:
     bump-version:
         name: Bump Version
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         outputs:
             new_version: ${{ steps.bump.outputs.version }}
             tag_name: ${{ steps.bump.outputs.tag }}

--- a/.github/workflows/shared-release-publish.yml
+++ b/.github/workflows/shared-release-publish.yml
@@ -19,6 +19,8 @@ jobs:
     release:
         name: Publish Release
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
 
         steps:
             -   name: Checkout

--- a/.github/workflows/shared-testing-gui-linux.yml
+++ b/.github/workflows/shared-testing-gui-linux.yml
@@ -145,6 +145,13 @@ jobs:
 
                     echo "All native DLLs present"
 
+            -   name: Export Actions Runtime
+                uses: actions/github-script@v8
+                with:
+                    script: |
+                        core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
+                        core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
+
             -   name: Run GUI Tests
                 run: |
                     echo "Starting desktop environment..."

--- a/.github/workflows/shared-testing-gui-linux.yml
+++ b/.github/workflows/shared-testing-gui-linux.yml
@@ -34,6 +34,7 @@ jobs:
                         arch: arm64
                         libName: linux
         permissions:
+            contents: read
             statuses: write
             checks: write
         steps:

--- a/.github/workflows/shared-testing-gui-macos.yml
+++ b/.github/workflows/shared-testing-gui-macos.yml
@@ -34,6 +34,7 @@ jobs:
                         arch: arm64
                         libName: osx
         permissions:
+            contents: read
             statuses: write
             checks: write
 

--- a/.github/workflows/shared-testing-gui-macos.yml
+++ b/.github/workflows/shared-testing-gui-macos.yml
@@ -110,6 +110,13 @@ jobs:
 
                     echo "All native DLLs present"
 
+            -   name: Export Actions Runtime
+                uses: actions/github-script@v8
+                with:
+                    script: |
+                        core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
+                        core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
+
             -   name: Run GUI Tests
                 run: |
                     echo "Setting up macOS GUI environment..."

--- a/.github/workflows/shared-testing-gui-windows.yml
+++ b/.github/workflows/shared-testing-gui-windows.yml
@@ -122,6 +122,13 @@ jobs:
 
                     Write-Host "All native DLLs present"
 
+            -   name: Export Actions Runtime
+                uses: actions/github-script@v8
+                with:
+                    script: |
+                        core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
+                        core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
+
             -   name: Run Tests
                 run: |
                     echo "Running tests on Windows..."

--- a/.github/workflows/shared-testing-gui-windows.yml
+++ b/.github/workflows/shared-testing-gui-windows.yml
@@ -34,6 +34,7 @@ jobs:
                         arch: arm64
                         libName: windows
         permissions:
+            contents: read
             statuses: write
             checks: write
 

--- a/.github/workflows/shared-testing-playwright-windows.yml
+++ b/.github/workflows/shared-testing-playwright-windows.yml
@@ -24,6 +24,7 @@ jobs:
             TARGET_SHA: ${{ inputs.target_sha }}
             WORKFLOW_URL: ${{ inputs.workflow_url }}
         permissions:
+            contents: read
             statuses: write
             checks: write
 

--- a/.github/workflows/shared-testing-python.yml
+++ b/.github/workflows/shared-testing-python.yml
@@ -1,4 +1,6 @@
 name: "Shared: Python Tests"
+permissions:
+    contents: read
 on:
     workflow_call:
 

--- a/.github/workflows/shared-testing.yml
+++ b/.github/workflows/shared-testing.yml
@@ -1,4 +1,6 @@
 name: "Shared: Platform Tests"
+permissions:
+    contents: read
 on:
     workflow_call:
         inputs:

--- a/.github/workflows/shared-testing.yml
+++ b/.github/workflows/shared-testing.yml
@@ -1,6 +1,8 @@
 name: "Shared: Platform Tests"
 permissions:
     contents: read
+    statuses: write
+    checks: write
 on:
     workflow_call:
         inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/InfiniLore/InfiniFrame/security/code-scanning/14](https://github.com/InfiniLore/InfiniFrame/security/code-scanning/14)

In general, the fix is to explicitly define a `permissions` block in the workflow (at the top level or per-job) that grants only the scopes needed for these tests. Since the shown jobs mainly resolve a PR’s head SHA via the API and then call other reusable workflows to run tests, they almost certainly only require read access to repository contents and metadata, not write access.

The simplest and least invasive fix, without altering functionality, is to add a workflow-level `permissions` block near the top of `.github/workflows/shared-testing.yml`, just under `name:` and before `on:`. A good secure baseline is `contents: read`, which allows checkout and basic API reads, and matches GitHub’s recommended minimal starting point. If other actions later in the called workflows require more specific permissions (e.g., `pull-requests: write`), those can be declared within those reusable workflows or as more granular adjustments, but that’s outside the provided snippet. No additional imports or methods are needed; this is purely a YAML configuration change.

Concretely: edit `.github/workflows/shared-testing.yml` so that after line 1 (`name: "Shared: Platform Tests"`) you add a `permissions:` block with `contents: read`. Leave the rest of the jobs and steps unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
