### PR TITLE
Feat: add sdk pinning in `global.json`

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 ﻿{
+  "sdk": {
+    "version": "10.0.201",
+    "rollForward": "latestPatch"
+  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 ﻿{
   "sdk": {
     "version": "10.0.201",
-    "rollForward": "latestPatch"
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
## Summary
Pin the .NET SDK in `global.json` and define explicit SDK resolution behavior so restore/build is more deterministic across CI and developer machines.

## Type of Change
<!-- Select the option(s) that best describe your PR by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature impacting existing APIs)
- [x] Refactor / Code cleanup (no functional change)
- [ ] Documentation update
- [ ] Test addition or update
- [x] Other (please describe):

## Affected Modules / Scope
<!-- Which part(s) of InfiniFrame does this touch? Select all that apply -->
<!-- Aligns with the issue templates "Scope" dropdown -->

- [ ] InfiniFrame
- [ ] InfiniFrame.Blazor
- [ ] InfiniFrame.BlazorWebView
- [ ] InfiniFrame.Js
- [ ] InfiniFrame.Native
- [ ] InfiniFrame.Shared
- [ ] InfiniFrame.WebServer
- [ ] InfiniFrame.Tools.Pack
- [ ] InfiniFrameExample
- [ ] InfiniFrameTests
- [x] Other: Repository-level .NET SDK/tooling configuration

## Changes Introduced
<!-- List key changes made in this PR -->
- Added `sdk.version` in `global.json`: `10.0.201`
- Added explicit `sdk.rollForward`: `latestPatch`
- Added `sdk.allowPrerelease`: `false` to avoid preview SDK selection

## Related Issues
<!-- Link relevant issues, e.g., Bug report, Feature request -->
<!-- Closes #issue_number -->
Closes #199 

## Checklist
<!-- Ensure your PR meets the project standards -->

- [x] My code follows InfiniFrame's coding conventions
- [ ] I added comments for complex or non-obvious code
- [ ] Documentation updated (if applicable)
- [ ] All tests pass locally
- [ ] Added new tests for any new functionality
- [ ] Existing tests pass
- [x] No new warnings or errors introduced
- [x] PR only includes changes relevant to the issue / feature

## 📖 Additional Context
<!-- Add any screenshots, diagrams, benchmarks, or explanations -->
This PR intentionally changes only `global.json` and keeps behavior strict but practical:
- deterministic SDK feature band (`10.0.201`)
- patch-only forward movement (`latestPatch`)
- stable release SDK usage (`allowPrerelease: false`)