### PR TITLE
Fix for Missed opportunity to use Where

### DIFF
--- a/src/InfiniFrame.Tools.Pack/Services/NativeRuntimeBuilder.cs
+++ b/src/InfiniFrame.Tools.Pack/Services/NativeRuntimeBuilder.cs
@@ -2,6 +2,7 @@
 // Imports
 // ---------------------------------------------------------------------------------------------------------------------
 using System.Buffers.Binary;
+using System.Linq;
 
 namespace InfiniFrame.Tools.Pack.Services;
 // ---------------------------------------------------------------------------------------------------------------------
@@ -31,8 +32,9 @@ internal static class NativeRuntimeBuilder {
             .Select(file => Path.IsPathRooted(file) ? file : Path.Join(nativeArtifactsDir, file))
             .ToArray();
         
-        foreach (string path in requiredPaths) {
-            if (!File.Exists(path)) throw new InvalidOperationException($"Required native artifact was not found: {path}");
+        string? missingPath = requiredPaths.FirstOrDefault(path => !File.Exists(path));
+        if (missingPath is not null) {
+            throw new InvalidOperationException($"Required native artifact was not found: {missingPath}");
         }
 
         foreach (string path in requiredPaths) {


### PR DESCRIPTION
In general, to address this type of issue you replace an implicit filter inside a `foreach` loop (where you check a condition and only act on items that fail/pass it) with an explicit LINQ filter (`Where`, possibly followed by `FirstOrDefault`, `Any`, or `ToList` depending on needs). This makes it clear that you're working with a subset of the original sequence and often results in more concise code.

For this specific loop, we want to preserve the current behavior: the method fails fast by throwing as soon as it finds a missing file. The simplest LINQ-based equivalent is to compute the first missing path using `FirstOrDefault` over a filtered sequence and then throw if such a path exists. Concretely, in `ValidateArtifacts` we will replace:

```csharp
foreach (string path in requiredPaths) {
    if (!File.Exists(path)) throw new InvalidOperationException($"Required native artifact was not found: {path}");
}
```

with:

```csharp
string? missingPath = requiredPaths.FirstOrDefault(path => !File.Exists(path));
if (missingPath is not null) {
    throw new InvalidOperationException($"Required native artifact was not found: {missingPath}");
}
```

This keeps the same semantics: it checks files in the same order and throws for the first missing one. To compile, we need `System.Linq` available. Since we cannot see the existing using directives beyond `using System.Buffers.Binary;`, we will add `using System.Linq;` at the top of the file. No other methods or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._