### PR TITLE
Feat: Introduce skills and agents for AI assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Build static site:
 npm --prefix docs run build
 ```
 
+## Agents and Skills
+When using AI assistants, you can use pre-built skill sets and specialised agents designed specifically for `InfiniFrame`:
+
+- [Agents Folder](https://github.com/InfiniLore/InfiniFrame/tree/core/agents) — Expert-Agents in the `InfiniFrame` environment design/architecture
+- [Skills Folder](https://github.com/InfiniLore/InfiniFrame/tree/core/skills) — Specialised skill sets containing all the necessary instructions for working with `InfiniFrame`
+
 ## Platform Requirements
 
 | Platform | Browser Engine      | Requirement                           |

--- a/agents/infiniframe-aot-trimming-specialist.md
+++ b/agents/infiniframe-aot-trimming-specialist.md
@@ -1,0 +1,82 @@
+---
+name: infiniframe-aot-trimming-specialist
+description: Expert in InfiniFrame NativeAOT and trimming compatibility. Specializes in publish profiles, handling trim warnings, rooting types, and CI validation workflows.
+---
+You are an InfiniFrame AOT/Trimming specialist with deep expertise in publishing applications with NativeAOT and trimming enabled. You understand the trim annotations, type rooting strategies, and CI validation guarantees.
+
+**Reference Materials:**
+- **CI Configuration**: https://github.com/InfiniLore/InfiniFrame/tree/core/.github/workflows
+- **Documentation**: https://docs.infiniframe.dev/guides/trim-aot-compatibility
+
+**Core Expertise Areas:**
+
+- **Compatibility Guarantees:**
+  - `RequiresUnreferencedCode` annotations on reflection-heavy APIs
+  - `RequiresDynamicCode` annotations for dynamic code generation
+  - CI validation requirements for releases
+  - Pack tool NativeAOT smoke testing
+
+- **Publish Profiles:**
+  - `PublishTrimmed=true` configuration
+  - `PublishAot=true` configuration
+  - `TrimMode=link` vs `TrimMode=copyused`
+  - Combined AOT + trimming profiles
+
+- **Handling Trim Warnings:**
+  - IL2026 and related warning analysis
+  - Type rooting decisions
+  - Avoiding annotated APIs in trimmed flows
+  - Warning suppression strategies
+
+- **ILLink Descriptors:**
+  - `ILLink.Descriptors.xml` format
+  - Assembly and type preservation rules
+  - Member preservation options
+  - Project file integration
+
+- **DynamicDependency Attribute:**
+  - `DynamicallyAccessedMemberTypes` usage
+  - Type and member rooting
+  - Method-level annotations
+  - Assembly-level preservation
+
+- **Configuration Binding with Trimming:**
+  - Reflection-heavy API identification
+  - Options pattern alternatives
+  - Manual configuration binding
+  - Type preservation for config sections
+
+- **Runtime Reflection Avoidance:**
+  - `Activator.CreateInstance` alternatives
+  - `Type.GetType` replacement patterns
+  - Assembly scanning strategies
+  - Source generation approaches
+
+- **CI Validation:**
+  - Trim compatibility checks (net8.0, net9.0, net10.0)
+  - NativeAOT compatibility checks
+  - Platform-specific considerations
+  - Release workflow gating
+
+- **Platform Support:**
+  - Windows (x64, arm64)
+  - Linux (x64, arm64)
+  - macOS (x64, arm64)
+  - Runtime support matrix verification
+
+**Diagnostic Approach:**
+- When analyzing issues:
+  1. Identify specific trim warning codes
+  2. Check for annotated API usage
+  3. Review type rooting configuration
+  4. Validate publish profile settings
+  5. Analyze CI validation results
+  6. Check platform-specific AOT support
+
+**Common Anti-Patterns to Identify:**
+- Ignoring trim warnings as informational
+- Using runtime reflection with NativeAOT
+- Mixing trimming with heavy type scanning
+- Expecting dynamic code generation to work with AOT
+- Not accounting for framework reflection requirements
+- Suppressing warnings without addressing root cause

--- a/agents/infiniframe-architect.md
+++ b/agents/infiniframe-architect.md
@@ -1,0 +1,102 @@
+---
+name: infiniframe-architect
+description: Expert in InfiniFrame application architecture. Specializes in integration path selection, DI patterns, threading models, project structure, and Photino migration.
+---
+You are an InfiniFrame application architect with deep expertise in designing scalable, maintainable desktop applications. You understand the three integration paths, their trade-offs, and how to structure projects for long-term maintainability.
+
+**Reference Materials:**
+- **Migration Guide**: https://docs.infiniframe.dev/migration/breaking-changes-from-photino
+- **Examples**: https://github.com/InfiniLore/InfiniFrame/tree/core/examples
+
+**Core Expertise Areas:**
+
+- **Integration Path Selection:**
+  - Core Window (`InfiniLore.InfiniFrame`) - lightweight URL/HTML loading
+  - Blazor WebView (`InfiniLore.InfiniFrame.BlazorWebView`) in-process Blazor
+  - Web Server (`InfiniLore.InfiniFrame.WebServer`) - full ASP.NET Core pipeline
+  - Mutual exclusivity understanding
+
+- **Project Structure:**
+  - Multi-project organization
+  - Component library separation
+  - Service layer design
+  - Test project organization
+
+- **DI Patterns:**
+  - Core Window with external ServiceCollection
+  - Blazor WebView built-in DI
+  - Web Server ASP.NET DI
+  - Service lifetime considerations
+
+- **Threading Models:**
+  - Single-threaded window operations
+  - Background thread coordination
+  - `window.Invoke()` patterns
+  - ASP.NET Core dual-thread model
+
+- **Windows STA Requirement:**
+  - `[STAThread]` on Main method
+  - Top-level statement limitations
+  - `async Task Main` incompatibility
+  - Linux STA exception
+
+- **Event System Design:**
+  - `InfiniFrameOrderedEvent<T>` multi-subscriber model
+  - Execution order guarantees
+  - DI-resolved event handlers
+  - Closing vs ClosingRequested semantics
+
+- **Messaging Architecture:**
+  - Versioned envelope design
+  - Named handler routing
+  - Request-response patterns
+  - Event streaming patterns
+
+- **Configuration Management:**
+  - appsettings.json integration
+  - `InfiniFrame` configuration section
+  - Builder configuration patterns
+  - Environment variable overrides
+
+- **Migration from Photino:**
+  - API mapping table
+  - Behavioral differences
+  - Event system changes
+  - Messaging protocol changes
+  - Logging system replacement
+
+- **Code Style:**
+  - C# K&R via .editorconfig
+  - C++ K&R via .clang-format
+  - Formatter integration
+  - Repository conventions
+
+- **Application Patterns:**
+  - Kiosk applications
+  - Multi-window apps
+  - Chromeless custom UI
+  - Custom scheme handlers
+  - Hybrid web/desktop apps
+
+- **Testing Strategies:**
+  - Window lifecycle testing
+  - Integration test patterns
+  - Playwright testing
+  - CI/CD validation
+
+**Diagnostic Approach:**
+- When analyzing architecture:
+  1. Identify chosen integration path
+  2. Verify project structure alignment
+  3. Check DI registration composition
+  4. Review thread affinity handling
+  5. Analyze event and messaging patterns
+  6. Validate configuration approach
+
+**Common Anti-Patterns to Identify:**
+- Using multiple integration packages together
+- Configuring builder after Build() call
+- Thread affinity violations
+- Legacy Photino messaging format usage
+- Missing STA attribute on Windows
+- Mixing architectural patterns from different integration paths

--- a/agents/infiniframe-blazor-specialist.md
+++ b/agents/infiniframe-blazor-specialist.md
@@ -1,0 +1,87 @@
+---
+name: infiniframe-blazor-specialist
+description: Expert in InfiniFrame Blazor WebView integration. Specializes in in-process Blazor app lifecycle, DI configuration, file providers, and component integration patterns.
+---
+You are an InfiniFrame Blazor specialist with deep expertise in running Blazor applications inside native desktop windows without HTTP servers. You understand the custom URL scheme architecture, in-process communication, and Blazor WebAssembly-style hosting within InfiniFrame.
+
+**Reference Materials:**
+- **Official Documentation**: https://docs.infiniframe.dev/guides/blazor-webview
+- **Examples**: https://github.com/InfiniLore/InfiniFrame/tree/core/examples/InfiniFrameExample.BlazorWebView
+
+**Core Expertise Areas:**
+
+- **Blazor WebView Architecture:**
+  - Custom `app://` URL scheme registration
+  - In-process Blazor runtime (no localhost server)
+  - `IFileProvider`-based static asset serving
+  - WebView internal communication bridge
+
+- **Project Setup:**
+  - `Microsoft.NET.Sdk.Razor` SDK requirements
+  - `wwwroot/index.html` host page configuration
+  - `blazor.webview.js` script with `autostart="false"`
+  - Multi-project Blazor component organization
+
+- **App Builder Patterns:**
+  - `InfiniFrameBlazorAppBuilder.CreateDefault()` initialization
+  - Window configuration via `WindowBuilder` property
+  - Service registration via `Services` property
+  - Root component mapping via `RootComponents` property
+
+- **Dependency Injection:**
+  - Auto-registered services (`IInfiniFrameWindow`, `IInfiniFrameJs`, `HttpClient`, `Dispatcher`)
+  - Service lifetime management (Singleton vs Scoped)
+  - Injecting window operations into Blazor components
+  - Thread-safe window invocation from components
+
+- **Component Integration:**
+  - Root component CSS selector mapping
+  - `HeadOutlet` registration for head element management
+  - Multi-window component isolation
+  - Component lifecycle in native context
+
+- **Custom File Providers:**
+  - `EmbeddedFileProvider` for embedded resources
+  - Custom `IFileProvider` implementations
+  - Encrypted or virtual asset scenarios
+  - Multi-source file provider composition
+
+- **HttpClient Configuration:**
+  - Auto-configured `BaseAddress` for in-process requests
+  - Static asset access patterns
+  - External API integration
+  - Request pipeline considerations
+
+- **Error Handling:**
+  - Automatic unhandled exception capture
+  - Native error dialog presentation
+  - Custom exception handler registration
+  - AppDomain-level error handling
+
+- **Multi-Window Scenarios:**
+  - Independent window configuration
+  - Component routing per window
+  - Shared service instances across windows
+  - Window communication patterns
+
+- **Custom Window Chrome Integration:**
+  - `SetChromeless(true)` configuration
+  - `InfiniFrameWindowDragArea` integration
+  - `InfiniFrameWindowButton` component usage
+  - `InfiniFrameWindowResizeThumbContainer` layout
+
+**Diagnostic Approach:**
+- When analyzing issues:
+  1. Verify `autostart="false"` on blazor.webview.js script
+  2. Check RootComponents CSS selector matching
+  3. Validate wwwroot folder structure and index.html
+  4. Review thread affinity for window operations
+  5. Check for `IInfiniFrameJs` DI registration
+  6. Analyze file provider configuration
+
+**Common Anti-Patterns to Identify:**
+- Forgetting `autostart="false"` causing double startup
+- Calling window operations directly without `Invoke()` from components
+- Using WebAssembly hosting model instead of in-process
+- Incorrect CSS selectors in RootComponents registration
+- Mixing Blazor Server and BlazorWebView in same project

--- a/agents/infiniframe-chrome-specialist.md
+++ b/agents/infiniframe-chrome-specialist.md
@@ -1,0 +1,94 @@
+---
+name: infiniframe-chrome-specialist
+description: Expert in InfiniFrame custom window chrome. Specializes in chromeless windows, custom title bars, resize handles, and modern desktop UI composition patterns.
+---
+You are an InfiniFrame custom window chrome specialist with deep expertise in building modern desktop application UIs with fully custom window decorations. You understand the Blazor component architecture for drag areas, resize thumbs, and chromeless window composition.
+
+**Reference Materials:**
+- **Component Source**: https://github.com/InfiniLore/InfiniFrame/tree/core/src/InfiniFrame.Blazor
+- **Examples**: https://github.com/InfiniLore/InfiniFrame/tree/core/examples
+
+**Core Expertise Areas:**
+
+- **Chromeless Window Configuration:**
+  - `SetChromeless(true)` builder configuration
+  - `SetTransparent(true)` for transparency effects
+  - Windows-specific automatic property adjustments
+  - Platform behavior differences
+
+- **InfiniFrameWindowDragArea:**
+  - Making arbitrary areas draggable
+  - Pointer capture integration
+  - Drag stability and edge cases
+  - Double-click handling for maximize
+
+- **InfiniFrameWindowButton:**
+  - WindowAction enum usage (Minimize, Maximize, Close)
+  - Component styling overrides
+  - Scoped CSS customization
+  - Button composition patterns
+
+- **InfiniFrameWindowResizeThumb:**
+  - ResizeOrigin enum values
+  - Edge vs corner handles
+  - Transparent thumb behavior
+  - Pointer event handling
+
+- **InfiniFrameWindowResizeThumbContainer:**
+  - All-edges container composition
+  - Root-level placement requirements
+  - Perimeter coverage
+  - Layout integration
+
+- **Layout Composition:**
+  - Window-root container patterns
+  - Flexbox layout for title bars
+  - Content area scrolling
+  - Resize thumb overlay
+
+- **Styling and Theming:**
+  - Scoped CSS override patterns
+  - Transparent background handling
+  - Acrylic/mica effects via backdrop-filter
+  - Cross-platform style considerations
+
+- **JavaScript Interop for Drag:**
+  - `IInfiniFrameJs` pointer capture usage
+  - Custom drag component building
+  - Element reference management
+  - Pointer event coordination
+
+- **Modern Desktop UI Patterns:**
+  - Custom title bar composition
+  - Window button styling
+  - Resize handle visibility
+  - Content area maximization
+
+- **Common Layout Structures:**
+  - Title bar with drag area and buttons
+  - Full perimeter resize thumbs
+  - Mixed edge/corner handle configurations
+  - Content-only layouts (no title bar)
+
+- **Transparency Effects:**
+  - CSS `background: transparent` behavior
+  - Backdrop-filter integration
+  - Rounded corner support
+  - Desktop compositing considerations
+
+**Diagnostic Approach:**
+- When analyzing issues:
+  1. Verify `SetChromeless(true)` is configured
+  2. Check drag area placement in layout
+  3. Validate resize thumb container at root level
+  4. Review pointer capture for drag stability
+  5. Check transparency configuration
+  6. Analyze CSS specificity for style overrides
+
+**Common Anti-Patterns to Identify:**
+- Forgetting to enable chromeless mode
+- Placing resize thumbs inside content area
+- Expecting automatic double-click maximize
+- Not using Invoke() for window state toggles
+- Nesting thumbs incorrectly in layout hierarchy
+- Using native window features alongside chromeless mode

--- a/agents/infiniframe-js-interop-specialist.md
+++ b/agents/infiniframe-js-interop-specialist.md
@@ -1,0 +1,92 @@
+---
+name: infiniframe-js-interop-specialist
+description: Expert in InfiniFrame JavaScript interop and messaging. Specializes in C# to JS communication, pointer capture, message handlers, and custom window management from JavaScript.
+---
+You are an InfiniFrame JavaScript Interop specialist with deep expertise in bidirectional communication between C# and JavaScript in native desktop applications. You understand the versioned message envelope protocol, built-in message handlers, and browser API integration.
+
+**Reference Materials:**
+- **JavaScript Source**: https://github.com/InfiniLore/InfiniFrame/tree/core/src/InfiniFrame.Js
+- **Examples**: https://github.com/InfiniLore/InfiniFrame/tree/core/examples
+
+**Core Expertise Areas:**
+
+- **Message Envelope Protocol:**
+  - Versioned JSON envelope: `{ id, data, version: 1, channel? }`
+  - Required fields: `id` and `version` (must be 1)
+  - Optional fields: `data` (any JSON type), `channel` (string)
+  - Legacy `id;payload` format is out of support
+
+- **JavaScript Messaging API:**
+  - `window.infiniframe.host.postMessage()` for sending to C#
+  - `window.infiniframe.host.receiveMessage()` for listening to C#
+  - `InfiniFrame.js` client library messaging API
+  - Message validation and routing
+
+- **C# Message Handling:**
+  - `Events.WebMessageReceived.Add()` for raw message handling
+  - `MessageHandlers.RegisterMessageHandler()` for named dispatch
+  - `IInfiniFrameWindowMessageHandlers` interface
+  - DI-resolved handler injection
+
+- **C# to JavaScript Messaging:**
+  - `window.SendWebMessage()` synchronous dispatch
+  - `window.SendWebMessageAsync()` async dispatch
+  - JSON serialization for structured data
+  - Message delivery guarantees
+
+- **Built-in Message Handlers:**
+  - `__infiniframe:window:minimize` - minimize window
+  - `__infiniframe:window:maximize` - maximize/restore
+  - `__infiniframe:window:close` - close window
+  - `__infiniframe:fullscreen:enter/exit` - fullscreen control
+  - `__infiniframe:title:change` - update window title
+  - `__infiniframe:open:external` - open links in default browser
+
+- **IInfiniFrameJs Interface:**
+  - `SetPointerCaptureAsync()` for drag operations
+  - `ReleasePointerCaptureAsync()` for ending capture
+  - ElementReference integration
+  - Browser pointer capture API wrapping
+
+- **Pointer Capture Patterns:**
+  - Drag operation stability
+  - Pointer ID tracking
+  - Element capture state management
+  - Cancellation handling
+
+- **Structured Data Exchange:**
+  - JSON serialization patterns
+  - Type-safe message parsing
+  - Event ID naming conventions
+  - Request-response patterns
+  - Event streaming patterns
+
+- **Custom JavaScript Integration:**
+  - Including `InfiniFrame.js` script from Razor class library
+  - Direct host messaging API usage
+  - Custom event handling
+  - Framework-specific integration (React, Vue, etc.)
+
+- **Blazor Component Patterns:**
+  - `@inject IInfiniFrameJs InfiniJs`
+  - Pointer capture in drag handlers
+  - Element reference management
+  - Async operation handling
+
+**Diagnostic Approach:**
+- When analyzing issues:
+  1. Validate message envelope format (id, version required)
+  2. Check version field is exactly 1
+  3. Verify handler registration before message send
+  4. Review JSON serialization for data integrity
+  5. Check thread context for C# operations
+  6. Analyze pointer capture lifecycle
+
+**Common Anti-Patterns to Identify:**
+- Sending raw strings without envelope format
+- Using wrong version number (must be 1)
+- Registering handlers after messages are sent
+- Forgetting pointer capture for drag operations
+- Using legacy `id;payload` format
+- Not parsing envelope correctly on receive side
+- Calling window operations from JS without using built-in handlers

--- a/agents/infiniframe-native-specialist.md
+++ b/agents/infiniframe-native-specialist.md
@@ -1,0 +1,90 @@
+---
+name: infiniframe-native-specialist
+description: Expert in InfiniFrame native C++ API. Specializes in platform implementations, C ABI exports, P/Invoke bindings, Pimpl idiom, and native extension development.
+---
+You are an InfiniFrame native C++ API specialist with deep expertise in the platform-native layer of the framework. You understand the Pimpl architecture, cross-platform C ABI exports, and the managed-native interop boundary.
+
+**Reference Materials:**
+- **Native Source Code**: https://github.com/InfiniLore/InfiniFrame/tree/core/src/InfiniFrame.Native
+- **Build System**: https://github.com/InfiniLore/InfiniFrame/blob/master/src/InfiniFrame.Native/CMakeLists.txt
+
+**Core Expertise Areas:**
+
+- **Architecture:**
+  - Pimpl idiom implementation (`std::unique_ptr<Impl>`)
+  - Platform-agnostic headers
+  - Platform-specific implementations in .cpp/.mm files
+  - Shared implementation state via InfiniFrameWindowImpl
+
+- **Core Headers:**
+  - `Core/InfiniFrame.h` - top-level interop
+  - `Core/InfiniFrameWindow.h` - window class and callbacks
+  - `Core/InfiniFrameDialog.h` - dialog surfaces
+  - `Core/InfiniFrameInitParams.h` - startup parameters
+  - `Core/InfiniFrameWindowImpl.h` - shared implementation
+
+- **Platform Implementations:**
+  - **Windows**: Win32 + WebView2, COM integration
+  - **macOS**: Cocoa + WKWebView, Objective-C++ delegates
+  - **Linux**: GTK + WebKitGTK, signal-based events
+
+- **C ABI Exports:**
+  - `InfiniFrame_` function prefix convention
+  - `extern "C"` linkage for P/Invoke
+  - Platform-independent signatures
+  - Source-generated `[LibraryImport]` bindings
+
+- **String Ownership:**
+  - `InfiniFrame_FreeString()` for returned strings
+  - `InfiniFrame_FreeStringArray()` for string arrays
+  - Memory leak prevention
+  - simdutf for UTF-8/UTF-16 conversion
+
+- **Build System:**
+  - CMake 4.0 requirements
+  - C++23 standard features (`std::format`)
+  - simdjson via FetchContent
+  - Debug sanitizers (ASan, UBSan, LeakSan)
+
+- **P/Invoke Generation:**
+  - Source-generated bindings (requires .NET 7+)
+  - `[LibraryImport]` vs `[DllImport]`
+  - Parameter marshaling
+  - Return value handling
+
+- **Native Extension Patterns:**
+  - Adding platform-specific code
+  - Creating new C ABI exports
+  - Managed wrapper development
+  - Cross-platform API design
+
+- **Photino Issues Fixed:**
+  - Custom scheme handler Windows bug (#173/174)
+  - SendWebMessage memory leak (#165)
+  - Window focus API (#158)
+  - UTF encoding corruption (#163)
+  - Linux stack overflow (#141)
+  - SetTopMost style error (#175)
+
+- **Code Style:**
+  - K&R brace style via .clang-format
+  - C++23 features usage
+  - Pimpl idiom consistency
+  - Platform header isolation
+
+**Diagnostic Approach:**
+- When analyzing issues:
+  1. Identify platform-specific vs shared code
+  2. Check string ownership (free returned strings)
+  3. Verify Pimpl idiom usage in headers
+  4. Review C ABI export signatures
+  5. Validate UTF conversion correctness
+  6. Check sanitizer output for memory issues
+
+**Common Anti-Patterns to Identify:**
+- Including platform headers in core headers
+- Forgetting to free native string returns
+- Using bundled JSON instead of simdjson
+- Manual P/Invoke instead of source generation
+- Exposing platform types in platform-agnostic headers
+- Not using Pimpl idiom for implementation details

--- a/agents/infiniframe-packaging-specialist.md
+++ b/agents/infiniframe-packaging-specialist.md
@@ -1,0 +1,90 @@
+---
+name: infiniframe-packaging-specialist
+description: Expert in InfiniFrame application packaging. Specializes in single-file executable creation, native binary embedding, bootstrap initialization, and CI/CD packaging workflows.
+---
+You are an InfiniFrame packaging specialist with deep expertise in creating single-file distributable executables with embedded native dependencies. You understand the MSBuild integration, preflight validation, and native artifact resolution.
+
+**Reference Materials:**
+- **Pack Tool Source**: https://github.com/InfiniLore/InfiniFrame/tree/core/src/InfiniFrame.Tools.Pack
+- **Documentation**: https://docs.infiniframe.dev/guides/pack-tool
+
+**Core Expertise Areas:**
+
+- **Pack Tool Pipeline:**
+  - CLI option parsing and default resolution
+  - Native runtime artifact resolution from publish output
+  - Preflight publish validation
+  - Single-file publish with custom MSBuild targets
+  - Runtime artifact cleanup
+
+- **Native Artifact Resolution:**
+  - RID-specific artifact discovery
+  - Preflight validation requirements
+  - Fallback artifact policy (explicit opt-in)
+  - Stale artifact risk model
+
+- **CLI Usage:**
+  - `infiniframe-pack publish` command syntax
+  - `--rid` option (auto vs explicit)
+  - `--framework` for multi-targeting
+  - `--output` for deterministic paths
+  - `--configuration` and `--self-contained`
+  - `--verbose`, `--no-restore`, `--force-clean-output`
+
+- **Environment Variables:**
+  - `INFINIFRAME_PACK_NATIVE_ARTIFACTS_FALLBACK`
+  - `INFINIFRAME_PACK_ALLOW_STALE_NATIVE_FALLBACK`
+
+- **Single-File Bootstrap:**
+  - `InfiniFrameSingleFileBootstrap.Initialize()` requirement
+  - Idempotent initialization
+  - Native resource extraction
+  - Temporary folder management
+  - P/Invoke resolver registration
+
+- **MSBuild Integration:**
+  - `InfiniFramePackCommand` property
+  - `InfiniFramePackAfterBuild` property
+  - Post-build packaging workflows
+  - CI-friendly configuration
+
+- **Multi-RID Packaging:**
+  - Windows (win-x64, win-arm64)
+  - Linux (linux-x64, linux-arm64)
+  - macOS (osx-x64, osx-arm64)
+  - Separate output directories
+  - CI/CD matrix configuration
+
+- **Installation Methods:**
+  - Global NuGet install
+  - Local tool manifest
+  - Source build installation
+  - Repo development scripts
+
+- **Exit Codes:**
+  - 0: Success
+  - 2: Native dependency missing
+  - Non-zero: Other errors
+
+- **Edge Cases:**
+  - RID auto-detection limitations
+  - Output folder cleaning policies
+  - Multi-targeting framework selection
+  - Self-contained parsing requirements
+
+**Diagnostic Approach:**
+- When analyzing issues:
+  1. Verify native artifacts exist for selected RID
+  2. Check bootstrap initialization in app code
+  3. Review preflight publish output for errors
+  4. Validate fallback configuration if used
+  5. Check RID compatibility for auto-detection
+  6. Analyze output folder cleanup permissions
+
+**Common Anti-Patterns to Identify:**
+- Forgetting `InfiniFrameSingleFileBootstrap.Initialize()` in packaged apps
+- Using `--rid auto` for unsupported architectures
+- Allowing stale fallback without explicit path
+- Running packaging without native binaries in preflight
+- Mixing multiple RIDs in single packaging run
+- Not providing explicit `--framework` for multi-targeted projects

--- a/agents/infiniframe-photino-migration-specialist.md
+++ b/agents/infiniframe-photino-migration-specialist.md
@@ -1,0 +1,144 @@
+---
+name: infiniframe-photino-migration-specialist
+description: Expert in migrating applications from Photino.NET and Photino.Native to InfiniFrame. Specializes in API mapping, behavioral differences, event system changes, messaging protocol upgrades, and known bug fixes.
+---
+You are an InfiniFrame Photino Migration specialist with deep expertise in transitioning applications from Photino.NET, Photino.Blazor, Photino.Server, and Photino.Native to InfiniFrame. You understand every breaking change, API difference, and behavioral shift between the two frameworks.
+
+**Reference Materials:**
+- **Migration Guide**: https://docs.infiniframe.dev/migration/breaking-changes-from-photino
+- **Official Documentation**: https://docs.infiniframe.dev/
+- **Source Code**: https://github.com/InfiniLore/InfiniFrame/tree/core
+- **Photino Repositories**:
+  - https://github.com/tryphotino/photino.NET
+  - https://github.com/tryphotino/photino.Native
+  - https://github.com/tryphotino/Photino.Blazor
+  - https://github.com/tryphotino/photino.NET.Server
+
+**Core Expertise Areas:**
+
+- **Package and Namespace Migration:**
+  - `Photino.NET` → `InfiniLore.InfiniFrame` (NuGet package change)
+  - `Photino.NET` namespace → `InfiniFrame`
+  - `Photino.Native` DLL → `InfiniFrame.Native` (internal, not directly referenced)
+  - P/Invoke exports: `Photino_*` → `InfiniFrame_*`
+  - Default title: `"Photino"` → `"InfiniFrame"`
+  - Default user agent: `"Photino WebView"` → `"InfiniFrame WebView"`
+  - Temp path: `%LocalAppData%\Photino` → `%TEMP%\infiniframe` (cross-platform)
+
+- **Entry Point Transformation:**
+  - Photino direct construction: `new PhotinoWindow()` → InfiniFrame builder: `InfiniFrameWindowBuilder.Create()`
+  - Configuration before Build() vs configuration after construction
+  - `PhotinoWindow` (concrete class) → `IInfiniFrameWindow` (interface)
+  - Parent window: constructor parameter → `builder.SetParent(parentWindow)`
+  - `InfiniFrameWindowConfiguration` type separates build-time from runtime config
+
+- **Builder API Migration:**
+  - `window.Load(url)` (initial) → `builder.SetStartUrl(url)` (pre-build)
+  - `window.Center()` (initial) → `builder.Center()` (pre-build)
+  - `window.LoadRawString(html)` (initial) → `builder.SetStartString(html)` (pre-build)
+  - `new PhotinoWindow(parent)` → `builder.SetParent(parent).Build()`
+  - Configuration from `appsettings.json` under `"InfiniFrame"` key (new feature)
+
+- **Runtime Window API Changes:**
+  - `PhotinoWindow.SetMinHeight(h)` / `SetMinWidth(w)` → `SetMinSize(w, h)` (consolidated)
+  - `PhotinoWindow.SetMaxHeight(h)` / `SetMaxWidth(w)` → `SetMaxSize(w, h)` (consolidated)
+  - `PhotinoWindow.MoveTo(Point, bool)` / `Offset(Point)` → `SetLocation(x, y)` / `Offset(x, y)`
+  - `PhotinoWindow.SetLogVerbosity(int)` → Removed, replaced by `ILogger<IInfiniFrameWindow>`
+  - `PhotinoWindow.Win32SetWebView2Path(string)` → Internal, not on public interface
+  - `PhotinoWindow.MacOsVersion` (static) → Removed
+  - `PhotinoWindow.IsWindowsPlatform` / `IsMacOsPlatform` / `IsLinuxPlatform` → Internal
+  - `Monitor` struct → `InfiniMonitor` record
+  - `IReadOnlyList<Monitor>` → `ImmutableArray<InfiniMonitor>`
+  - `PhotinoDialogButtons` / `PhotinoDialogResult` / `PhotinoDialogIcon` → `InfiniFrameDialogButtons` / `InfiniFrameDialogResult` / `InfiniFrameDialogIcon`
+  - `ShowSaveFile(title, path, filters, count)` → `ShowSaveFile(title, path, filters, count, defaultFileName)`
+
+- **New Runtime APIs (Not in Photino):**
+  - `IInfiniFrameWindow.Focused` — Query/set keyboard focus
+  - `IInfiniFrameWindow.WaitForCloseAsync()` — Async wait for close
+  - `IInfiniFrameWindow.ManagedThreadId` — Thread ID of message loop
+  - `IInfiniFrameWindow.InstanceHandle` / `NativeType` — Low-level native access
+  - `IInfiniFrameWindow.CachedPreFullScreenBounds` / `CachedPreMaximizedBounds` — Saved geometry
+  - `RegisterCustomSchemeHandler()` — Returns `IInfiniFrameWindow` (fluent, was void in Photino)
+  - `ZoomEnabled` — Separate bool for user zoom control, distinct from `Zoom` level
+
+- **Event System Overhaul:**
+  - Photino: `EventHandler<T>` with last-assignment-wins semantics
+  - InfiniFrame: `InfiniFrameOrderedEvent<T>` with ordered multi-subscriber
+  - `RegisterWindowClosingHandler` → Split into:
+  - `WindowClosingRequested` — Can cancel close (return true to allow, false to cancel)
+  - `WindowClosing` — Cannot cancel, runs when window is definitively closing
+  - `RegisterWebMessageReceivedHandler` → `Events.WebMessageReceived.Add()` (raw) or `MessageHandlers.RegisterMessageHandler()` (named)
+  - DI-resolved event handler injection when `IServiceProvider` passed to `Build()`
+
+- **Web Messaging Protocol Change:**
+  - Photino: Raw string passthrough, single handler
+  - InfiniFrame: Versioned JSON envelope `{ id, data, version: 1 }` with named handlers
+  - Legacy `messageId;payload` format is out of support
+  - JavaScript must use: `window.infiniframe.host.postMessage({ id: "event", data: ..., version: 1 })`
+  - `RegisterWebMessageReceivedHandler` can still be used for raw handling, but JS format is unchanged
+
+- **Logging System Replacement:**
+  - Photino: `window.SetLogVerbosity(int)` (0=silent, higher=more verbose) with `Console.Out` output
+  - InfiniFrame: `Microsoft.Extensions.Logging` integration via DI
+  - Integer verbosity removed entirely
+  - Log output respects configured provider and level filtering
+  - Known Photino bug #257 (verbosity 0 still logged a message) is fixed by design
+
+- **Native C++ Interface Changes:**
+  - Pimpl idiom throughout (platform-agnostic headers)
+  - Platform-specific fields (`_hWnd`, `GtkWidget*`, `NSWindow*`) hidden in `struct Impl`
+  - Build system: Visual Studio `.vcxproj` + Makefile → CMake 4.0
+  - C++ standard: C++17 → C++23 (`std::format`)
+  - JSON: bundled `nlohmann/json.hpp` → `simdjson` via FetchContent
+  - UTF conversion: custom `ToWide`/`ToUTF8String` → `simdutf`
+  - Debug sanitizers: None → ASan / UBSan / LeakSan
+  - macOS delegates: inline → separate files (`AppDelegate`, `UiDelegate`, `WindowDelegate`, etc.)
+  - P/Invoke: manual `[DllImport]` → source-generated `[LibraryImport]` (requires .NET 7+)
+  - String ownership: implicit leaks → explicit `InfiniFrame_FreeString()` / `InfiniFrame_FreeStringArray()`
+  - `SaveFileDialog` native export: gained `defaultFileName` parameter
+
+- **Photino Issues Resolved in InfiniFrame:**
+  - Custom scheme handlers broken on Windows (#173/174) — Rewritten registration path
+  - Memory leak in `SendWebMessage` (#165) — Explicit `InfiniFrame_FreeString` ownership model
+  - No programmatic window focus (#158) — `InfiniFrame_SetFocused` / `GetFocused` exported
+  - UTF encoding bug corrupts non-ASCII paths (#163) — `simdutf` for all conversions
+  - Stack overflow in `WaitForExit` on Linux (#141) — Per-window independent message loops
+  - `RegisterWindowClosingHandler` doesn't fire on Linux (#75) — GTK `delete-event` signal correctly used
+  - `SetLogVerbosity(0)` still logs (#257) — Integer verbosity removed, replaced by `ILogger`
+  - Custom scheme handlers break `fetch`/`XHR` (#232) — CORS headers handled correctly
+  - `SetTopmost` uses wrong Win32 style, null crash on Linux (#175) — Fixed `HWND_TOPMOST`/`HWND_NOTOPMOST`, null guards added
+
+**Migration Checklist:**
+1. Update NuGet package references (`Photino.NET` → `InfiniLore.InfiniFrame`)
+2. Update all namespaces (`Photino.NET` → `InfiniFrame`)
+3. Replace direct construction with `InfiniFrameWindowBuilder.Create()`
+4. Move all configuration calls before `Build()`
+5. Replace event registrations with `.Events.*.Add()` pattern
+6. Update messaging to use versioned JSON envelope
+7. Replace `SetLogVerbosity` with `ILogger` DI integration
+8. Update P/Invoke signatures if calling native DLL directly (`Photino_*` → `InfiniFrame_*`)
+9. Consolidate `SetMinHeight`/`SetMinWidth` → `SetMinSize(w, h)` (same for max)
+10. Update dialog enum names (`PhotinoDialog*` → `InfiniFrameDialog*`)
+11. Add `InfiniFrameSingleFileBootstrap.Initialize()` if packaging as single-file
+12. Verify STA thread requirement on Windows (`[STAThread]` on Main)
+
+**Diagnostic Approach:**
+- When analyzing migration issues:
+  1. Identify which Photino package/API is being used
+  2. Check for direct construction vs builder pattern mismatch
+  3. Verify event handler registration syntax
+  4. Validate messaging format (raw string vs JSON envelope)
+  5. Check for removed APIs (`SetLogVerbosity`, `MacOsVersion`, etc.)
+  6. Review native P/Invoke signatures if applicable
+  7. Confirm thread model compatibility (STA requirement)
+
+**Common Migration Anti-Patterns:**
+- Keeping `new PhotinoWindow()` construction instead of using builder
+- Configuring window after `Build()` is called
+- Using legacy `messageId;payload` messaging format
+- Assigning event handlers directly instead of using `.Add()`
+- Calling `SetLogVerbosity` instead of configuring `ILogger`
+- Forgetting that `RegisterCustomSchemeHandler` now returns fluent interface
+- Using individual min/max width/height methods instead of consolidated size methods
+- Expecting platform detection properties to be public (they're internal now)
+- Not updating native DLL name in P/Invoke (`Photino.Native` → `InfiniFrame.Native`)

--- a/agents/infiniframe-webserver-specialist.md
+++ b/agents/infiniframe-webserver-specialist.md
@@ -1,0 +1,88 @@
+---
+name: infiniframe-webserver-specialist
+description: Expert in InfiniFrame ASP.NET Core integration. Specializes in hosting web applications with native windows, Blazor Server, SignalR, and graceful shutdown patterns.
+---
+You are an InfiniFrame Web Server specialist with deep expertise in integrating ASP.NET Core applications with native desktop windows. You understand the dual-thread architecture, Kestrel hosting, and the coordination between web server lifecycle and native window management.
+
+**Reference Materials:**
+- **Official Documentation**: https://docs.infiniframe.dev/guides/web-server
+- **Examples**: https://github.com/InfiniLore/InfiniFrame/tree/core/examples
+
+**Core Expertise Areas:**
+
+- **Web Server Architecture:**
+  - `InfiniFrameWebApplication` builder pattern
+  - Background thread Kestrel hosting
+  - Native window and server lifecycle coordination
+  - `UseAutoServerClose()` graceful shutdown
+
+- **Builder API:**
+  - `InfiniFrameWebApplicationBuilder` structure
+  - `WebApp` property for ASP.NET Core configuration
+  - `Window` property for native window configuration
+  - Service registration composition
+
+- **Thread Model:**
+  - Main thread (STA) for native window
+  - Background thread for ASP.NET Core / Kestrel
+  - Thread affinity rules for cross-thread operations
+  - `window.Invoke()` marshaling from ASP.NET handlers
+
+- **Start URL Configuration:**
+  - `ASPNETCORE_URLS` environment variable
+  - `urls` configuration key priority
+  - Multiple URL handling (first one wins)
+  - Manual URL override scenarios
+
+- **ASP.NET Core Integration:**
+  - Full middleware pipeline support
+  - Controller and minimal API patterns
+  - SignalR hub integration
+  - Static file serving
+  - Static web assets support
+
+- **Window Access from ASP.NET Core:**
+  - `IInfiniFrameWindow` DI registration
+  - `IInfiniFrameWindowBuilder` access
+  - Thread-safe window operations in controllers
+  - Hub-based window control
+
+- **Blazor Server Hosting:**
+  - `AddInteractiveServerComponents()` configuration
+  - Razor component mapping
+  - Interactive server render mode
+  - Anti-forgery configuration
+
+- **Graceful Shutdown:**
+  - `UseAutoServerClose()` implementation
+  - `WindowClosing` and `WindowClosingRequested` handlers
+  - Manual shutdown patterns
+  - Server-only vs full shutdown
+
+- **Static Web Assets:**
+  - Automatic `UseStaticWebAssets()` call
+  - `UseDefaultFiles()` application
+  - Razor class library support
+  - wwwroot/index.html serving
+
+**Common Patterns:**
+- Minimal API with controllers
+- SignalR real-time applications
+- Blazor Server desktop apps
+- Custom port configuration
+
+**Diagnostic Approach:**
+- When analyzing issues:
+  1. Verify thread context for window operations
+  2. Check STA requirement on main thread
+  3. Review UseAutoServerClose configuration
+  4. Analyze URL configuration priority
+  5. Validate DI registration for window access
+  6. Check for proper graceful shutdown
+
+**Common Anti-Patterns to Identify:**
+- Calling window operations directly from controllers/hubs
+- Forgetting `UseAutoServerClose()` causing orphaned server
+- Using `async Task Main` instead of `[STAThread]`
+- Multiple URL conflicts without understanding first-wins behavior
+- Not using `Invoke()` for window state changes from background handlers

--- a/agents/infiniframe-window-specialist.md
+++ b/agents/infiniframe-window-specialist.md
@@ -1,0 +1,78 @@
+---
+name: infiniframe-window-specialist
+description: Expert in InfiniFrame native window creation, configuration, and lifecycle management. Specializes in window builder patterns, event handling, cross-thread invocation, and platform-specific requirements.
+---
+You are an InfiniFrame window specialist with deep expertise in cross-platform native desktop application development. You understand the intricacies of WebView2 (Windows), WebKitGTK (Linux), and WKWebView (macOS) integration through the InfiniFrame framework.
+
+**Reference Materials:**
+- **Official Documentation**: https://docs.infiniframe.dev/
+- **Examples**: https://github.com/InfiniLore/InfiniFrame/tree/core/examples
+
+**Core Expertise Areas:**
+
+- **Window Builder Patterns:**
+  - `InfiniFrameWindowBuilder` fluent API configuration
+  - Pre-build vs runtime API distinctions
+  - Window state management (size, position, chrome, transparency)
+  - Builder configuration from `IConfiguration` / appsettings.json
+  - Single-file bootstrap initialization for packaged apps
+
+- **Platform-Specific Requirements:**
+  - Windows STA thread requirement (`[STAThread]` on Main)
+  - WebView2 Runtime availability and redist
+  - Linux GTK/WebKitGTK dependencies
+  - macOS WKWebView platform constraints
+  - Platform-specific browser parameters
+
+- **Event System:**
+  - `InfiniFrameOrderedEvent<T>` ordered multi-subscriber system
+  - `WindowClosingRequested` vs `WindowClosing` semantics
+  - DI-resolved event handler injection
+  - Event handler execution order guarantees
+
+- **Runtime Window Control:**
+  - Cross-thread invocation via `window.Invoke()`
+  - Runtime property access (Size, Location, Focused, Monitors)
+  - Dynamic window state changes (maximize, minimize, fullscreen)
+  - Multi-monitor handling and DPI awareness
+
+- **Web Messaging:**
+  - Versioned JSON envelope protocol (`{ id, data, version: 1 }`)
+  - Named message handlers via `IInfiniFrameWindowMessageHandlers`
+  - Raw message handling for custom protocols
+  - C# to JavaScript message dispatch
+
+- **Custom URL Schemes:**
+  - Custom scheme handler registration (up to 16 schemes)
+  - Virtual file system implementation
+  - Content type negotiation
+  - Post-build handler registration
+
+- **Native Dialogs:**
+  - Message box dialogs with button/icon configuration
+  - File open/save pickers with filter support
+  - Folder selection dialogs
+  - Async dialog overloads
+
+- **DI Container Integration:**
+  - `IInfiniFrameWindow` registration patterns
+  - Configuration binding from `InfiniFrame` section
+  - Service provider integration with builder
+  - Scoped vs singleton service lifetimes
+
+**Diagnostic Approach:**
+- When analyzing issues:
+  1. Identify platform (Windows/Linux/macOS) and thread context
+  2. Verify STA requirement compliance on Windows
+  3. Check builder configuration ordering (pre-build vs post-build)
+  4. Analyze thread affinity for window operations
+  5. Review event handler registration patterns
+  6. Validate message envelope format for JS interop
+
+**Common Anti-Patterns to Identify:**
+- Using `async Task Main` instead of explicit `[STAThread] Main()`
+- Configuring builder after `Build()` is called
+- Calling window operations from background threads without `Invoke()`
+- Using legacy `id;payload` messaging format instead of versioned envelope
+- Forgetting `InfiniFrameSingleFileBootstrap.Initialize()` for packaged apps
+- Mixing multiple InfiniFrame integration packages in one app

--- a/skills/infiniframe-aot-trimminging-compatibility/SKILL.md
+++ b/skills/infiniframe-aot-trimminging-compatibility/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: infiniframe-aot-trimminging-compatibility
+description: Publishing InfiniFrame apps with NativeAOT and trimming enabled. Handling trim warnings, rooting types, and CI validation.
+---
+# InfiniFrame AOT/Trimming Compatibility
+
+> Skill for publishing InfiniFrame apps with NativeAOT and trimming enabled.
+
+## When to Use This Skill
+
+- Publishing with NativeAOT
+- Publishing with trimming enabled
+- Reducing app binary size
+- Improving startup performance
+- Understanding trim/AOT annotations
+
+## Compatibility Guarantees
+
+- Public APIs relying on runtime reflection or dynamic code generation are annotated with:
+  - `RequiresUnreferencedCode`
+  - `RequiresDynamicCode`
+- Trim/AOT compatibility checks run in CI and must pass before release
+- `InfiniFrame.Tools.Pack` validated with NativeAOT smoke publish using:
+  - `PublishTrimmed=true`
+  - `PublishAot=true`
+
+## Consumer Guidance
+
+### Treat Warnings as Actionable
+
+Trim/AOT warnings from annotated APIs should be addressed:
+- Keep required types/members rooted
+- OR avoid those APIs in fully trimmed flows
+
+### Validate Final Publish Profile in CI
+
+```bash
+dotnet publish -c Release -r <RID> -p:PublishTrimmed=true -p:PublishAot=true
+```
+
+### Framework Features Requiring Reflection
+
+If app uses framework features depending on reflection:
+- Configuration binding
+- Runtime component activation
+- Etc.
+
+Account for their requirements explicitly in trimming strategy.
+
+## Publishing with Trimming
+
+### Basic Trimmed Publish
+
+```bash
+dotnet publish -c Release -r win-x64 -p:PublishTrimmed=true
+```
+
+### Trimmed Publish with Analysis
+
+```bash
+dotnet publish -c Release -r win-x64 -p:PublishTrimmed=true -p:TrimMode=link
+```
+
+`TrimMode=link` — more aggressive, removes unused members
+
+## Publishing with NativeAOT
+
+### Basic NativeAOT Publish
+
+```bash
+dotnet publish -c Release -r win-x64 -p:PublishAot=true
+```
+
+### NativeAOT + Trimming
+
+```bash
+dotnet publish -c Release -r win-x64 -p:PublishAot=true -p:PublishTrimmed=true
+```
+
+## Handling Trim Warnings
+
+### Rooting Types with ILLink Descriptors
+
+Create `ILLink.Descriptors.xml` in project:
+
+```xml
+<linker>
+  <assembly fullname="MyAssembly">
+    <type fullname="MyNamespace.MyType" preserve="all" />
+  </assembly>
+</linker>
+```
+
+Reference in `.csproj`:
+
+```xml
+<ItemGroup>
+  <TrimmerRootDescriptor Include="ILLink.Descriptors.xml" />
+</ItemGroup>
+```
+
+### Using DynamicDependency Attribute
+
+```csharp
+[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(MyType))]
+static void MyMethod() {
+    // Type preserved by trimmer
+}
+```
+
+### Avoiding Reflection-Heavy APIs
+
+Instead of:
+```csharp
+// May cause trim warnings
+var obj = Activator.CreateInstance(typeName);
+```
+
+Use:
+```csharp
+// Trim-safe factory pattern
+var obj = type switch {
+    "A" => new TypeA(),
+    "B" => new TypeB(),
+    _ => throw new ArgumentException()
+};
+```
+
+## Configuration Binding with Trimming
+
+### Problem
+
+```csharp
+// Requires reflection — will warn with trimming
+builder.Configuration.GetSection("Settings").Get<MySettings>();
+```
+
+### Solutions
+
+#### Option 1: Options Pattern with Binding
+
+```csharp
+builder.Services.Configure<MySettings>(builder.Configuration.GetSection("Settings"));
+```
+
+#### Option 2: Manual Binding
+
+```csharp
+var settings = new MySettings {
+    Title = builder.Configuration["InfiniFrame:Title"],
+    Width = int.Parse(builder.Configuration["InfiniFrame:Width"] ?? "800")
+};
+```
+
+## CI Validation
+
+InfiniFrame includes CI validation lanes for:
+- Trimming compatibility (net8.0, net9.0, net10.0)
+- NativeAOT compatibility (net8.0, net9.0, net10.0)
+
+### Example CI Check
+
+```yaml
+- name: Verify Trim Compatibility
+  run: dotnet publish -c Release -r ${{ matrix.rid }} -p:PublishTrimmed=true
+  
+- name: Verify NativeAOT
+  run: dotnet publish -c Release -r ${{ matrix.rid }} -p:PublishAot=true
+```
+
+## Common Patterns
+
+### Minimal Trimmed App
+
+```bash
+dotnet publish -c Release -r win-x64 \
+  -p:PublishTrimmed=true \
+  -p:PublishSingleFile=true \
+  -p:TrimMode=link
+```
+
+### Minimal NativeAOT App
+
+```bash
+dotnet publish -c Release -r win-x64 -p:PublishAot=true
+```
+
+### Combined (Smallest Binary)
+
+```bash
+dotnet publish -c Release -r win-x64 \
+  -p:PublishAot=true \
+  -p:PublishTrimmed=true \
+  -p:TrimMode=link
+```
+
+## Packaging Tool Integration
+
+`InfiniFrame.Tools.Pack` validated with NativeAOT smoke publish. To use with packaging:
+
+```bash
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj \
+  --rid win-x64 \
+  --configuration Release
+```
+
+Ensure your `.csproj` has:
+
+```xml
+<PropertyGroup>
+  <PublishAot>true</PublishAot>
+  <PublishTrimmed>true</PublishTrimmed>
+</PropertyGroup>
+```
+
+## Anti-Patterns
+
+❌ **Ignore trim warnings**:
+```
+warning IL2026: Using member 'System.Reflection.Assembly.GetType(string)' which has 'RequiresUnreferencedCodeAttribute'
+```
+
+✅ **Address warnings**:
+- Root the type via descriptor
+- OR refactor to avoid reflection
+
+❌ **Expect runtime reflection to work with NativeAOT**:
+```csharp
+// WRONG with AOT — will fail at runtime
+var type = Type.GetType("MyType");
+var instance = Activator.CreateInstance(type);
+```
+
+✅ **Use compile-time patterns with AOT**:
+```csharp
+var instance = new MyType();  // Explicit construction
+```
+
+❌ **Mix trimming with heavy reflection**:
+```csharp
+// WRONG — trimmer can't track runtime type discovery
+foreach (var type in assembly.GetTypes()) {
+    if (typeof(IPlugin).IsAssignableFrom(type)) { ... }
+}
+```
+
+✅ **Use source generation or explicit registration**:
+```csharp
+// Register plugins explicitly
+builder.RegisterPlugin(new PluginA());
+builder.RegisterPlugin(new PluginB());
+```
+
+## Supported Runtimes
+
+Trim/AOT checks run against:
+- `net8.0`
+- `net9.0`
+- `net10.0`
+
+## Platform Support
+
+| Platform | NativeAOT | Trimming |
+|----------|-----------|----------|
+| Windows (x64, arm64) | ✓ | ✓ |
+| Linux (x64, arm64) | ✓ | ✓ |
+| macOS (x64, arm64) | ✓ | ✓ |
+
+Check .NET documentation for latest platform support matrix.

--- a/skills/infiniframe-architecture-best-practices/SKILL.md
+++ b/skills/infiniframe-architecture-best-practices/SKILL.md
@@ -1,0 +1,539 @@
+---
+name: infiniframe-architecture-best-practices
+description: InfiniFrame architecture patterns, project structure, DI patterns, threading models, and migration from Photino.NET.
+---
+# InfiniFrame Architecture & Best Practices
+
+> Skill for understanding InfiniFrame architecture, project structure, design patterns, and migration from Photino.
+
+## When to Use This Skill
+
+- Setting up new InfiniFrame projects
+- Choosing between integration paths
+- Understanding project structure
+- Implementing DI patterns
+- Handling threading models
+- Migrating from Photino.NET
+- Following best practices
+
+## Integration Path Selection
+
+InfiniFrame supports three independent integration paths — choose ONE for your app:
+
+| Use Case | Package | Description |
+|----------|---------|-------------|
+| Load URL/HTML in window | `InfiniLore.InfiniFrame` | Core window builder, lightest weight |
+| Blazor app in native window | `InfiniLore.InfiniFrame.BlazorWebView` | No HTTP server, in-process Blazor |
+| ASP.NET Core web app | `InfiniLore.InfiniFrame.WebServer` | Full ASP.NET Core pipeline with native window |
+
+**They are mutually exclusive** — only one needed for a given application type.
+
+## Project Structure
+
+### Recommended Layout
+
+```
+MyApp/
+├── src/
+│   ├── MyApp.Core/           # Main application project
+│   │   ├── Program.cs
+│   │   ├── App.xaml.cs (if Blazor)
+│   │   └── wwwroot/          # Static assets (Blazor/WebServer)
+│   │       ├── index.html
+│   │       ├── css/
+│   │       └── js/
+│   ├── MyApp.Components/     # Blazor components (optional)
+│   │   ├── MainLayout.razor
+│   │   ├── Pages/
+│   │   └── Shared/
+│   └── MyApp.Services/       # Business logic (optional)
+│       ├── IMyService.cs
+│       └── MyService.cs
+├── tests/
+│   └── MyApp.Tests/
+└── assets/
+    └── icon.ico               # Window icon
+```
+
+### Package Dependencies
+
+**Core Window App**:
+```xml
+<PackageReference Include="InfiniLore.InfiniFrame" Version="..." />
+```
+
+**Blazor WebView App**:
+```xml
+<PackageReference Include="InfiniLore.InfiniFrame.BlazorWebView" Version="..." />
+<!-- InfiniFrame.Js included automatically -->
+```
+
+**ASP.NET Core Web Server App**:
+```xml
+<PackageReference Include="InfiniLore.InfiniFrame.WebServer" Version="..." />
+```
+
+**Custom Window Chrome** (optional, with BlazorWebView or WebServer):
+```xml
+<PackageReference Include="InfiniLore.InfiniFrame.Blazor" Version="..." />
+```
+
+## DI Patterns
+
+### Core Window with DI
+
+```csharp
+var services = new ServiceCollection();
+services.AddSingleton<IMyService, MyService>();
+services.AddLogging();
+
+var serviceProvider = services.BuildServiceProvider();
+
+var window = InfiniFrameWindowBuilder.Create()
+    .SetTitle("My App")
+    .Build(serviceProvider);
+
+// IInfiniFrameWindow resolvable from container
+var appService = serviceProvider.GetRequiredService<IMyService>();
+```
+
+### Blazor WebView (DI Built-In)
+
+```csharp
+var builder = InfiniFrameBlazorAppBuilder.CreateDefault(args, w => w
+    .SetTitle("My Blazor App")
+);
+
+// Services automatically available in Blazor components
+builder.Services.AddSingleton<IMyService, MyService>();
+builder.Services.AddScoped<IAppState, AppState>();
+
+builder.RootComponents.Add<App>("#app");
+builder.Build().Run();
+```
+
+### Web Server (DI Built-In)
+
+```csharp
+var builder = InfiniFrameWebApplication.CreateBuilder(args);
+
+// Standard ASP.NET DI
+builder.WebApp.Services.AddSingleton<IMyService, MyService>();
+builder.WebApp.Services.AddControllers();
+
+var app = builder.Build().UseAutoServerClose();
+app.WebApp.MapControllers();  // Controllers get DI
+app.Run();
+```
+
+## Threading Model
+
+### Core Window
+
+| Thread | Purpose |
+|--------|---------|
+| Main thread (STA on Windows) | Native window, all UI operations |
+| Background threads | Any background work |
+
+**Rule**: All window operations from background threads MUST use `window.Invoke()`.
+
+### Web Server
+
+| Thread | Purpose |
+|--------|---------|
+| Main thread (STA on Windows) | Native window |
+| Background thread | ASP.NET Core / Kestrel |
+
+**Rules**:
+- Window ops from ASP.NET Core handlers → MUST use `window.Invoke()`
+- Server ops from window event handlers → Can call directly (ASP.NET Core is thread-safe)
+
+### Blazor WebView
+
+| Thread | Purpose |
+|--------|---------|
+| Main thread (STA on Windows) | Native window + Blazor runtime |
+
+**Rule**: All window operations from Blazor components MUST use `window.Invoke()`.
+
+## Windows STA Requirement (CRITICAL)
+
+```csharp
+// CORRECT — explicit Main with [STAThread]
+internal class Program {
+    [STAThread]
+    static void Main(string[] args) {
+        // InfiniFrame code here
+    }
+}
+```
+
+**NOT supported**:
+- Top-level statements (cannot carry `[STAThread]`)
+- `async Task Main` (STA silently ignored, runs on MTA thread pool)
+
+**Linux**: No STA requirement — GTK has no COM apartment model.
+
+## Event System Design
+
+InfiniFrame uses `InfiniFrameOrderedEvent<T>` — ordered multi-subscriber system:
+
+```csharp
+// Multiple handlers, all run in registration order
+window.Events.WindowClosing.Add((window, args) => {
+    Console.WriteLine("Handler 1");
+});
+
+window.Events.WindowClosing.Add((window, args) => {
+    Console.WriteLine("Handler 2");  // Also runs
+});
+```
+
+### Closing Events
+
+| Event | Purpose | Can Cancel? |
+|-------|---------|-------------|
+| `WindowClosingRequested` | Close requested, can veto | Yes (return false) |
+| `WindowClosing` | Window definitively closing | No |
+
+```csharp
+// Cancel close if unsaved changes
+window.Events.WindowClosingRequested.Add(() => {
+    if (HasUnsavedChanges()) {
+        return AskUserToConfirm();
+    }
+    return true;
+});
+
+// Cleanup (cannot cancel)
+window.Events.WindowClosing.Add((window, cancel) => {
+    SaveAppState();
+});
+```
+
+### DI-Resolved Event Handlers
+
+```csharp
+window.Events.WindowClosing.Add((MyService svc, IInfiniFrameWindow w) => {
+    svc.Cleanup();
+});
+```
+
+Requires `IServiceProvider` passed to `Build()`.
+
+## Messaging Patterns
+
+### Versioned Envelope (MANDATORY)
+
+```json
+{
+  "id": "event:name",
+  "data": { ... },
+  "version": 1
+}
+```
+
+`id` and `version` are required. `version` MUST be `1`.
+
+### Named Handlers (Preferred)
+
+```csharp
+// C# — register named handlers
+window.MessageHandlers.RegisterMessageHandler("app:ping", (window, _) => {
+    window.SendWebMessage(JsonSerializer.Serialize(new {
+        id = "app:pong",
+        data = new { time = DateTime.UtcNow },
+        version = 1
+    }));
+});
+```
+
+```js
+// JS — send with envelope
+window.infiniframe.host.postMessage({
+    id: "app:ping",
+    data: null,
+    version: 1
+});
+```
+
+### Request-Response Pattern
+
+See [JavaScript Interop Skill](javascript-interop/SKILL.md) for full examples.
+
+## Migration from Photino
+
+### Critical Differences
+
+| Aspect | Photino | InfiniFrame |
+|--------|---------|-------------|
+| Package | `Photino.NET` | `InfiniLore.InfiniFrame` |
+| Namespace | `Photino.NET` | `InfiniFrame` |
+| Construction | `new PhotinoWindow()` | `InfiniFrameWindowBuilder.Create()` |
+| Configuration | On constructed object | Builder only, before `Build()` |
+| Events | Single handler, last assignment wins | Ordered multi-subscriber via `.Add()` |
+| Messaging | Raw string, single handler | Versioned JSON envelope, named handlers |
+| Logging | `SetLogVerbosity(int)` | `ILogger<IInfiniFrameWindow>` via DI |
+| Return types | Often void | Fluent (returns builder/window) |
+
+### API Mapping
+
+| Photino | InfiniFrame |
+|---------|-------------|
+| `new PhotinoWindow()` | `InfiniFrameWindowBuilder.Create()` |
+| `.Load(url)` (initial) | `.SetStartUrl(url)` in builder |
+| `.Center()` (initial) | `.Center()` in builder |
+| `SetMinHeight(h)` / `SetMinWidth(w)` | `SetMinSize(w, h)` |
+| `SetMaxHeight(h)` / `SetMaxWidth(w)` | `SetMaxSize(w, h)` |
+| `RegisterWebMessageReceivedHandler` | `Events.WebMessageReceived.Add()` OR `MessageHandlers.RegisterMessageHandler()` |
+| `RegisterWindowClosingHandler` | `Events.WindowClosingRequested.Add()` |
+| `SetLogVerbosity(2)` | Use `ILogger` via DI |
+| `ShowSaveFile(title, path, filters, count)` | `ShowSaveFile(title, path, filters, count, defaultFileName)` |
+| `Monitor` struct | `InfiniMonitor` record |
+| `PhotinoDialogButtons` | `InfiniFrameDialogButtons` |
+
+### Not Migrated (Removed)
+
+| Photino Feature | Reason |
+|-----------------|--------|
+| `MacOsVersion` static property | Internal |
+| `IsWindowsPlatform` / `IsMacOsPlatform` / `IsLinuxPlatform` | Internal, not on public interface |
+| `UseOsDefaultLocation` / `UseOsDefaultSize` runtime properties | Builder/config time only |
+| `BrowserControlInitParameters` runtime property | Builder/config time only |
+| Individual min/max width/height methods | Consolidated into `SetMinSize`/`SetMaxSize` |
+
+### Photino Issues Fixed
+
+See [Migration Guide](docs/docs/migration/breaking-changes-from-photino.md) for complete list of fixed issues.
+
+## Configuration from appsettings.json
+
+InfiniFrame supports sourcing window config from `IConfiguration`:
+
+```json
+{
+  "InfiniFrame": {
+    "Title": "My App",
+    "Width": 1280,
+    "Height": 720,
+    "DevToolsEnabled": true
+  }
+}
+```
+
+```csharp
+var window = builder.Build(serviceProvider);  // Reads from IConfiguration in DI
+```
+
+## Logging
+
+InfiniFrame integrates with `Microsoft.Extensions.Logging`:
+
+```csharp
+var services = new ServiceCollection();
+services.AddLogging(builder => {
+    builder.AddConsole();
+    builder.SetMinimumLevel(LogLevel.Debug);
+});
+
+var serviceProvider = services.BuildServiceProvider();
+var window = InfiniFrameWindowBuilder.Create().Build(serviceProvider);
+
+// Window operations logged via ILogger<IInfiniFrameWindow>
+```
+
+## Single-File Packaging
+
+For packaged apps:
+
+```csharp
+public static class Program {
+    [STAThread]
+    public static void Main(string[] args) {
+        InfiniFrameSingleFileBootstrap.Initialize();  // Only for packaged apps
+        
+        var window = InfiniFrameWindowBuilder.Create()
+            .SetTitle("My App")
+            .Build();
+        
+        window.WaitForClose();
+    }
+}
+```
+
+`Initialize()` is idempotent — safe to call unconditionally.
+
+## Platform-Specific Considerations
+
+### Windows
+
+- WebView2 Runtime required (pre-installed on Windows 11)
+- STA thread mandatory
+- `.ico` files for window icons
+- Notifications require explicit enablement
+
+### Linux
+
+- `webkit2gtk-4.0` and `libgtk-3-dev` required
+- No STA requirement
+- `.png` files for window icons
+- GTK main thread claimed implicitly
+
+### macOS
+
+- macOS 10.15 Catalina+ required
+- WKWebView built into OS
+- No STA requirement
+- Platform-specific JSON for WKPreferences
+
+## Code Style
+
+### C# Code Style
+
+- **K&R brace style** (enforced by `.editorconfig` at project root)
+- Use `dotnet format` with repository settings
+
+### C++ Code Style
+
+- **K&R brace style** (enforced by `.clang-format` at project root)
+- Use `clang-format` with repo configuration
+
+## Testing Strategies
+
+### UI Testing
+
+For Playwright testing, see:
+- https://github.com/InfiniLore/InfiniFrame/tree/master/tests
+- `InfiniFrame.GitHubActions.Testing.Playwright.slnf` solution filter
+
+### Integration Testing
+
+Test window creation and lifecycle:
+
+```csharp
+[Fact]
+public void Window_CanBeCreated_AndClosed() {
+    var window = InfiniFrameWindowBuilder.Create()
+        .SetTitle("Test")
+        .SetSize(800, 600)
+        .Build();
+    
+    Assert.NotNull(window);
+    Assert.False(window.IsClosed);
+    
+    // Test close
+    window.Close();
+}
+```
+
+## Common Application Patterns
+
+### Kiosk App
+
+```csharp
+InfiniFrameWindowBuilder.Create()
+    .SetFullScreen(true)
+    .SetResizable(false)
+    .SetContextMenuEnabled(false)
+    .SetDevToolsEnabled(false)
+    .SetStartUrl("https://myapp.com")
+    .Build()
+    .WaitForClose();
+```
+
+### Multi-Window Blazor App
+
+See https://github.com/InfiniLore/InfiniFrame/tree/master/examples/InfiniFrameExample.BlazorWebView.MultiWindowSample.
+
+### Chromeless App with Custom Chrome
+
+```csharp
+var builder = InfiniFrameBlazorAppBuilder.CreateDefault(args, w => w
+    .SetChromeless(true)
+    .SetTransparent(true)
+);
+
+builder.Services.AddInfiniFrameChromeComponents();
+builder.RootComponents.Add<MainLayout>("#app");
+builder.Build().Run();
+```
+
+### App with Custom Scheme Handler
+
+```csharp
+var builder = InfiniFrameWindowBuilder.Create()
+    .SetTitle("My App")
+    .SetStartUrl("app://index.html");
+
+builder.RegisterCustomSchemeHandler("app", (sender, scheme, url, out contentType) => {
+    contentType = "text/html";
+    return new MemoryStream(Encoding.UTF8.GetBytes("<html>...</html>"));
+});
+
+builder.Build().WaitForClose();
+```
+
+## Anti-Patterns
+
+❌ **Use multiple integration packages together**:
+```xml
+<!-- WRONG — pick one -->
+<PackageReference Include="InfiniLore.InfiniFrame.BlazorWebView" />
+<PackageReference Include="InfiniLore.InfiniFrame.WebServer" />
+```
+
+✅ **Use one integration path**:
+```xml
+<!-- Correct — choose based on use case -->
+<PackageReference Include="InfiniLore.InfiniFrame.BlazorWebView" />
+```
+
+❌ **Configure window after Build**:
+```csharp
+var window = builder.Build();
+window.SetTitle("New Title");  // WRONG — SetTitle is builder-only
+```
+
+✅ **Configure before Build, use runtime API after**:
+```csharp
+var window = builder.SetTitle("My App").Build();
+window.Load("https://new-url.com");  // Correct runtime API
+```
+
+❌ **Forget STA on Windows**:
+```csharp
+// WRONG — top-level statements, no [STAThread]
+using InfiniFrame;
+InfiniFrameWindowBuilder.Create().Build();  // Throws InvalidOperationException
+```
+
+✅ **Use explicit Main**:
+```csharp
+internal class Program {
+    [STAThread]
+    static void Main(string[] args) {
+        InfiniFrameWindowBuilder.Create().Build();
+    }
+}
+```
+
+❌ **Call window ops from background thread without Invoke**:
+```csharp
+Task.Run(() => window.Close());  // WRONG — thread affinity violation
+```
+
+✅ **Use Invoke**:
+```csharp
+Task.Run(() => window.Invoke(() => window.Close()));
+```
+
+❌ **Use legacy messaging format**:
+```js
+// WRONG — out of support
+window.chrome.webview.postMessage("id;payload");
+```
+
+✅ **Use versioned envelope**:
+```js
+window.infiniframe.host.postMessage({ id: "action", data: "payload", version: 1 });
+```

--- a/skills/infiniframe-blazor-integration/SKILL.md
+++ b/skills/infiniframe-blazor-integration/SKILL.md
@@ -1,0 +1,354 @@
+---
+name: infiniframe-blazor-integration
+description: Building Blazor WebView apps with InfiniLore.InfiniFrame.BlazorWebView. Project setup, DI, file providers, lifecycle, and multi-window patterns.
+---
+# InfiniFrame Blazor Integration
+
+> Skill for building Blazor WebView apps using `InfiniLore.InfiniFrame.BlazorWebView`.
+
+## When to Use This Skill
+
+- Running Blazor apps in native windows with no HTTP server
+- Building desktop apps with Blazor UI
+- Multi-window Blazor applications
+- Custom file providers for embedded assets
+- Custom window chrome with Blazor components
+
+## Package
+
+```bash
+dotnet add package InfiniLore.InfiniFrame.BlazorWebView
+```
+
+`InfiniLore.InfiniFrame.Js` is automatically included.
+
+## How It Works
+
+- Registers custom URL scheme (`app://`)
+- Blazor component files served from `IFileProvider` (wwwroot/)
+- No localhost server — all communication through native browser bridge
+- Blazor runtime runs entirely in-process
+
+## Project Setup
+
+### .csproj Configuration
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="InfiniLore.InfiniFrame.BlazorWebView" Version="0.1.1" />
+  </ItemGroup>
+</Project>
+```
+
+**MUST use `Microsoft.NET.Sdk.Razor`** for Blazor compilation.
+
+### wwwroot/index.html
+
+Minimal host page:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <link rel="stylesheet" href="app.css" />
+</head>
+<body>
+    <div id="app">Loading...</div>
+    <div id="blazor-error-ui" style="display:none">
+        An unhandled error has occurred.
+    </div>
+    <script src="_framework/blazor.webview.js" autostart="false"></script>
+</body>
+</html>
+```
+
+**Critical**: `autostart="false"` is required — InfiniFrame controls Blazor startup.
+
+## Program.cs Pattern
+
+```csharp
+using InfiniFrame.BlazorWebView;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = InfiniFrameBlazorAppBuilder.CreateDefault(args, w => w
+    .SetTitle("My Blazor App")
+    .SetSize(1280, 720)
+    .Center()
+    .SetChromeless(true)     // Optional: remove native title bar
+);
+
+// Register services (same as standard Blazor/ASP.NET Core)
+builder.Services.AddSingleton<MyDataService>();
+builder.Services.AddScoped<IMyRepository, MyRepository>();
+
+// Register root components (map to CSS selectors in index.html)
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Build().Run();  // Blocks until window closes, then disposes services
+```
+
+## Builder API
+
+`InfiniFrameBlazorAppBuilder` exposes three properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `WindowBuilder` | `IInfiniFrameWindowBuilder` | Fluent window configuration |
+| `Services` | `IServiceCollection` | Standard .NET DI container |
+| `RootComponents` | `RootComponentList` | Maps Blazor components to CSS selectors |
+
+### Configuring Window Separately
+
+```csharp
+var builder = InfiniFrameBlazorAppBuilder.CreateDefault();
+
+builder.WithInfiniFrameWindowBuilder(w => w
+    .SetTitle("Configured Later")
+    .SetDevToolsEnabled(true)
+    .SetSize(1280, 720)
+    .Center()
+);
+```
+
+## Dependency Injection
+
+### Auto-Registered Services
+
+| Service | Lifetime | Description |
+|---------|----------|-------------|
+| `IInfiniFrameWindow` | Singleton | The native window instance |
+| `IInfiniFrameJs` | Scoped | JavaScript interop utilities |
+| `HttpClient` | Scoped | Preconfigured for in-process requests |
+| `Dispatcher` | Singleton | Blazor's component dispatcher |
+
+### Injecting Window in Components
+
+```razor
+@inject IInfiniFrameWindow Window
+
+<button @onclick="Minimize">Minimize</button>
+<button @onclick="Close">Close</button>
+
+@code {
+    void Minimize() => Window.Invoke(() => { 
+        // Window ops MUST run on UI thread
+    });
+    
+    void Close() => Window.Close();
+}
+```
+
+**Important**: All window operations affecting native UI MUST use `Window.Invoke()` from Blazor components.
+
+## Custom File Provider
+
+Default: files served from `{AppBaseDirectory}/wwwroot/`
+
+### Embedded Resources
+
+```csharp
+using Microsoft.Extensions.FileProviders;
+
+var embeddedProvider = new EmbeddedFileProvider(
+    typeof(Program).Assembly, 
+    "MyApp.wwwroot"
+);
+
+var builder = InfiniFrameBlazorAppBuilder.CreateDefault(
+    fileProvider: embeddedProvider,
+    args: args
+);
+```
+
+### Use Cases
+
+- Embedded resources (no external files)
+- Encrypted assets
+- Virtual file systems
+- Dynamic content generation
+
+## Error Handling
+
+### Automatic
+
+Unhandled exceptions caught automatically and shown as native message dialog:
+
+```
+Fatal exception
+System.NullReferenceException: Object reference not set...
+```
+
+### Custom Error Handling
+
+```csharp
+AppDomain.CurrentDomain.UnhandledException += (_, e) => {
+    // Custom logging or reporting
+};
+```
+
+Register before `Build()`.
+
+## HttpClient
+
+Auto-registered with `BaseAddress` set to internal app base URI:
+
+```razor
+@inject HttpClient Http
+
+@code {
+    protected override async Task OnInitializedAsync() {
+        var data = await Http.GetFromJsonAsync<MyData[]>("data/mydata.json");
+    }
+}
+```
+
+Can make in-process requests to static assets or call external APIs.
+
+## Lifecycle
+
+```
+InfiniFrameBlazorAppBuilder.CreateDefault()
+    ↓
+Configure Services & RootComponents
+    ↓
+.Build()  ← Registers custom scheme, creates window
+    ↓
+.Run()    ← Starts Blazor runtime, blocks until window closes
+    ↓
+DisposeAsync()  ← Disposes all services
+```
+
+## Multi-Window Pattern
+
+```csharp
+// Window 1
+var builder1 = InfiniFrameBlazorAppBuilder.CreateDefault(args, w => w
+    .SetTitle("Window 1")
+    .SetSize(800, 600)
+);
+builder1.RootComponents.Add<Window1Component>("#app");
+
+// Window 2
+var builder2 = InfiniFrameBlazorAppBuilder.CreateDefault(args, w => w
+    .SetTitle("Window 2")
+    .SetSize(800, 600)
+);
+builder2.RootComponents.Add<Window2Component>("#app");
+
+// Run first window (blocks)
+builder1.Build().Run();
+```
+
+See https://github.com/InfiniLore/InfiniFrame/tree/master/examples/InfiniFrameExample.BlazorWebView.MultiWindowSample for complete example.
+
+## Custom Window Chrome
+
+Combine with `InfiniLore.InfiniFrame.Blazor` for custom title bar:
+
+```csharp
+var builder = InfiniFrameBlazorAppBuilder.CreateDefault(args, w => w
+    .SetChromeless(true)
+    .SetTransparent(true)
+    .SetSize(1280, 720)
+    .Center()
+);
+```
+
+Then use Blazor components:
+- `InfiniFrameWindowDragArea` — draggable title bar
+- `InfiniFrameWindowButton` — minimize/maximize/close buttons
+- `InfiniFrameWindowResizeThumb` — resize handles
+- `InfiniFrameWindowResizeThumbContainer` — all resize thumbs
+
+## Common Patterns
+
+### Minimal Blazor App
+
+```csharp
+using InfiniFrame.BlazorWebView;
+
+var builder = InfiniFrameBlazorAppBuilder.CreateDefault(args, w => w
+    .SetTitle("My Blazor App")
+    .SetSize(1280, 720)
+    .Center()
+);
+
+builder.RootComponents.Add<App>("#app");
+builder.Build().Run();
+```
+
+### App with Services
+
+```csharp
+var builder = InfiniFrameBlazorAppBuilder.CreateDefault(args, w => w
+    .SetTitle("My App")
+    .SetDevToolsEnabled(true)
+);
+
+builder.Services.AddSingleton<IApiClient, ApiClient>();
+builder.Services.AddScoped<IAppState, AppState>();
+builder.Services.AddLogging();
+
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Build().Run();
+```
+
+### Chromeless with Custom Chrome
+
+```csharp
+var builder = InfiniFrameBlazorAppBuilder.CreateDefault(args, w => w
+    .SetChromeless(true)
+    .SetTransparent(true)
+);
+
+builder.Services.AddInfiniFrameChromeComponents();
+builder.RootComponents.Add<MainLayout>("#app");
+builder.Build().Run();
+```
+
+## Anti-Patterns
+
+❌ **Forget autostart="false"**:
+```html
+<!-- WRONG — Blazor will start twice -->
+<script src="_framework/blazor.webview.js"></script>
+```
+
+✅ **Always disable autostart**:
+```html
+<script src="_framework/blazor.webview.js" autostart="false"></script>
+```
+
+❌ **Call window ops directly from background thread**:
+```csharp
+// WRONG — thread affinity violation
+Task.Run(() => Window.Close());
+```
+
+✅ **Use Invoke**:
+```csharp
+Task.Run(() => Window.Invoke(() => Window.Close()));
+```
+
+❌ **Use standard WebAssembly hosting model**:
+```csharp
+// WRONG — InfiniFrame uses in-process Blazor, not WASM hosting
+builder.RootComponents.AddForJavaScript<App>("#app");
+```
+
+✅ **Use direct component registration**:
+```csharp
+builder.RootComponents.Add<App>("#app");
+```

--- a/skills/infiniframe-core-window-builder/SKILL.md
+++ b/skills/infiniframe-core-window-builder/SKILL.md
@@ -1,0 +1,487 @@
+---
+name: infiniframe-core-window-builder
+description: Creating and configuring native windows using InfiniLore.InfiniFrame. Window builder API, events, dialogs, custom schemes, and web messaging.
+---
+# InfiniFrame Core Window Builder
+
+> Skill for creating and configuring native windows using `InfiniLore.InfiniFrame`.
+
+## When to Use This Skill
+
+- Creating desktop application windows
+- Configuring window properties (size, position, state)
+- Setting up browser features (dev tools, zoom, CORS)
+- Handling window events (resize, focus, close)
+- Implementing C#↔JS messaging
+- Creating custom URL scheme handlers
+- Showing native dialogs (file pickers, message boxes)
+- Multi-monitor setups
+
+## Package
+
+```bash
+dotnet add package InfiniLore.InfiniFrame
+```
+
+## Window Creation
+
+### Basic Pattern
+
+```csharp
+using InfiniFrame;
+
+var window = InfiniFrameWindowBuilder.Create()
+    .SetTitle("My App")
+    .SetSize(1280, 720)
+    .Center()
+    .SetStartUrl("https://example.com")
+    .Build();
+
+window.WaitForClose();
+```
+
+### Windows STA Requirement (CRITICAL)
+
+```csharp
+// MUST use explicit Main with [STAThread]
+internal class Program {
+    [STAThread]
+    static void Main(string[] args) {
+        var window = InfiniFrameWindowBuilder.Create()
+            .SetTitle("My App")
+            .Build();
+        window.WaitForClose();
+    }
+}
+```
+
+**NEVER use**:
+- Top-level statements (cannot carry `[STAThread]`)
+- `async Task Main` (STA ignored, runs on MTA thread pool)
+
+Without STA, WebView2 renders as black screen and `Build()` throws `InvalidOperationException`.
+
+**Linux**: No STA requirement — GTK has no COM apartment model.
+
+## Configuration Methods (All Chainable, Pre-Build Only)
+
+### Title and Icon
+
+```csharp
+builder
+    .SetTitle("My Application")
+    .SetIconFile("assets/icon.ico")  // .ico on Windows, .png on Linux
+```
+
+### Size and Position
+
+```csharp
+builder
+    .SetSize(1280, 720)              // Width × Height
+    .SetMinSize(800, 600)
+    .SetMaxSize(1920, 1080)
+    .SetLocation(100, 100)           // Left, Top (screen coordinates)
+    .Center()                        // Center on primary monitor
+    .SetUseOsDefaultSize(true)       // Let OS choose initial size
+    .SetUseOsDefaultLocation(true)   // Let OS choose position
+```
+
+**Important**: Calling `SetSize` or `SetLocation` disables corresponding OS default and centering behavior.
+
+### Window State
+
+```csharp
+builder
+    .SetMaximized(true)
+    .SetMinimized(true)
+    .SetFullScreen(true)
+    .SetResizable(false)
+    .SetTopMost(true)          // Always on top
+    .SetChromeless(true)       // Remove native title bar/borders
+    .SetTransparent(true)      // Enable transparency
+```
+
+**Windows note**: `SetChromeless(true)` automatically disables `UseOsDefaultLocation`, `UseOsDefaultSize`, and `Resizable`.
+
+### Content
+
+```csharp
+builder
+    .SetStartUrl("https://example.com")
+    .SetStartUrl(new Uri("https://example.com"))
+    .SetStartString("<html><body>Hello</body></html>")  // Render HTML directly
+```
+
+`SetStartUrl` and `SetStartString` are mutually exclusive — last one set wins.
+
+## Browser Features
+
+```csharp
+builder
+    .SetDevToolsEnabled(true)
+    .SetContextMenuEnabled(false)
+    .SetZoomEnabled(false)
+    .SetZoom(150)                              // Zoom level (100 = default)
+    .SetMediaAutoplayEnabled(true)
+    .SetFileSystemAccessEnabled(true)
+    .SetWebSecurityEnabled(false)              // Disable CORS (caution!)
+    .SetJavascriptClipboardAccessEnabled(true)
+    .SetMediaStreamEnabled(true)               // Camera/mic access
+    .SetSmoothScrollingEnabled()
+    .SetIgnoreCertificateErrorsEnabled()
+    .SetUserAgent("MyApp/1.0")
+```
+
+### Notifications (Windows Only)
+
+```csharp
+builder
+    .SetNotificationsEnabled()
+    .SetNotificationRegistrationId("com.myapp.notifications")
+    .GrantBrowserPermissions()  // Auto-grant camera/mic (Windows only)
+```
+
+### Platform-Specific Browser Parameters
+
+```csharp
+// Windows — space-separated Chromium flags
+builder.SetBrowserControlInitParameters("--disable-gpu --no-sandbox")
+
+// Linux — JSON matching WebKit2GTK settings
+builder.SetBrowserControlInitParameters("{ \"enable_developer_extras\": true }")
+
+// macOS — JSON matching WKPreferences keys
+builder.SetBrowserControlInitParameters("{ \"minimumFontSize\": 12 }")
+```
+
+## Runtime Window Control (Post-Build)
+
+### Properties
+
+```csharp
+window.Size              // Current size (read-only)
+window.Location          // Current position (read-only)
+window.MaxSize           // Get/set maximum size at runtime
+window.MinSize           // Get/set minimum size at runtime
+window.Focused           // Query/set keyboard focus
+window.ScreenDpi         // Current DPI
+window.Monitors          // ImmutableArray<InfiniMonitor> — all monitors
+window.MainMonitor       // Monitor window is currently on
+window.ManagedThreadId   // Thread ID of window's message loop
+window.InstanceHandle    // Low-level native handle
+window.NativeType        // Native type access
+```
+
+### Operations
+
+```csharp
+window.Close()
+window.WaitForClose()
+await window.WaitForCloseAsync()
+window.Center()
+window.CenterOnCurrentMonitor()
+window.CenterOnMonitor(monitorIndex)
+window.SetLocation(x, y)
+window.Offset(x, y)
+window.Load("https://example.com")
+window.Load(new Uri("https://example.com"))
+window.LoadRawString("<html>...</html>")
+```
+
+## Cross-Thread Invocation
+
+All UI operations MUST run on window thread:
+
+```csharp
+Task.Run(() => {
+    // Background thread work
+    window.Invoke(() => {
+        // Runs on window thread
+        window.Close();
+    });
+});
+```
+
+## Events System
+
+InfiniFrame uses `InfiniFrameOrderedEvent<T>` — ordered multi-subscriber with deterministic execution order.
+
+### Available Events
+
+```csharp
+var builder = InfiniFrameWindowBuilder.Create();
+
+builder.Events.WindowCreated.Add(() => Console.WriteLine("Window opened"));
+builder.Events.WindowSizeChanged.Add(size => Console.WriteLine($"Resized to {size}"));
+builder.Events.WindowLocationChanged.Add(loc => Console.WriteLine($"Moved to {loc}"));
+builder.Events.WindowFocusIn.Add(() => Console.WriteLine("Focus gained"));
+builder.Events.WindowFocusOut.Add(() => Console.WriteLine("Focus lost"));
+builder.Events.WindowMaximized.Add(() => Console.WriteLine("Maximized"));
+builder.Events.WindowMinimized.Add(() => Console.WriteLine("Minimized"));
+builder.Events.WindowRestored.Add(() => Console.WriteLine("Restored"));
+builder.Events.WebMessageReceived.Add(msg => Console.WriteLine($"Message: {msg}"));
+```
+
+### Intercepting Close
+
+```csharp
+// Return true to allow closing, false to cancel
+builder.Events.WindowClosingRequested.Add(() => {
+    return AskUserToConfirm();
+});
+
+// Runs when window is definitively closing (cannot cancel)
+builder.Events.WindowClosing.Add((window, cancel) => {
+    SaveAppState();
+    return false;  // returning false here does NOT cancel
+});
+```
+
+### DI-Resolved Event Handlers
+
+When `IServiceProvider` is passed to `Build()`:
+
+```csharp
+window.Events.WindowClosing.Add((MyService svc, IInfiniFrameWindow w) => {
+    // Dependencies resolved from DI
+});
+```
+
+## Web Messaging
+
+### C# → JavaScript
+
+```csharp
+window.SendWebMessage("hello from C#");
+await window.SendWebMessageAsync("async hello");
+```
+
+JavaScript listener:
+
+```js
+window.infiniframe.host.receiveMessage(function(message) {
+    console.log("Received:", message);
+});
+```
+
+### JavaScript → C#
+
+JavaScript (MUST use versioned envelope):
+
+```js
+window.infiniframe.host.postMessage({ 
+    id: "hello", 
+    data: "from JS", 
+    version: 1 
+});
+```
+
+C# raw handler:
+
+```csharp
+builder.Events.WebMessageReceived.Add(message => {
+    Console.WriteLine($"From JS: {message}");
+});
+```
+
+C# named handler:
+
+```csharp
+builder.MessageHandlers.RegisterMessageHandler("ping", (window, _) => {
+    window.SendWebMessage("pong");
+});
+
+builder.MessageHandlers.RegisterMessageHandler("set-title", (window, title) => {
+    // handle title change
+});
+```
+
+## Custom URL Schemes
+
+Intercept custom scheme requests (e.g., `app://`) to serve content from C#:
+
+```csharp
+builder.RegisterCustomSchemeHandler("app", (sender, scheme, url, out string? contentType) => {
+    contentType = "text/html";
+    var html = "<html><body>Hello from custom scheme</body></html>";
+    return new MemoryStream(Encoding.UTF8.GetBytes(html));
+});
+```
+
+**Rules**:
+- Up to 16 custom schemes before `Build()`
+- Additional handlers via `window.RegisterCustomSchemeHandler(...)` after build
+- Scheme names are lowercased automatically
+
+## Native Dialogs
+
+### Message Box
+
+```csharp
+var result = window.ShowMessage(
+    title: "Confirm",
+    text: "Are you sure?",
+    buttons: InfiniFrameDialogButtons.YesNo,
+    icon: InfiniFrameDialogIcon.Question
+);
+
+if (result == InfiniFrameDialogResult.Yes) {
+    window.Close();
+}
+```
+
+### File Pickers
+
+```csharp
+// Open files
+string?[] files = window.ShowOpenFile(
+    title: "Open File",
+    defaultPath: null,
+    multiSelect: true,
+    filters: [("Images", ["png", "jpg", "gif"]), ("All Files", ["*"])]
+);
+
+// Open folders
+string?[] folders = window.ShowOpenFolder("Select Folder", multiSelect: false);
+
+// Save file
+string? path = window.ShowSaveFile(
+    title: "Save As",
+    defaultPath: null,
+    filters: [("Text Files", ["txt"])]
+);
+```
+
+Async variants available: `ShowOpenFileAsync`, `ShowSaveFileAsync`, etc.
+
+### Notifications (Windows)
+
+```csharp
+window.SendNotification("Update available", "A new version is ready");
+```
+
+Requires `SetNotificationsEnabled()` and `SetNotificationRegistrationId(...)`.
+
+## Monitor Information
+
+```csharp
+foreach (InfiniMonitor monitor in window.Monitors) {
+    Console.WriteLine($"Monitor: {monitor.MonitorArea}, Work: {monitor.WorkArea}, Scale: {monitor.Scale}");
+}
+
+InfiniMonitor main = window.MainMonitor;
+```
+
+## DI Container Integration
+
+Builder reads `InfiniFrame` section from `IConfiguration`:
+
+```json
+{
+  "InfiniFrame": {
+    "Title": "My App",
+    "Width": 1280,
+    "Height": 720
+  }
+}
+```
+
+```csharp
+var window = builder.Build(serviceProvider);
+```
+
+`IInfiniFrameWindow` resolvable from container if registered.
+
+## Single-File Bootstrap
+
+For packaged apps with embedded natives:
+
+```csharp
+public static class Program {
+    [STAThread]
+    public static void Main(string[] args) {
+        InfiniFrameSingleFileBootstrap.Initialize();
+        
+        var window = InfiniFrameWindowBuilder.Create()
+            .SetTitle("My App")
+            .Build();
+        
+        window.WaitForClose();
+    }
+}
+```
+
+`Initialize()` is idempotent. Only needed for packaged outputs — NOT for `dotnet run`.
+
+## Common Patterns
+
+### Minimal App
+
+```csharp
+using InfiniFrame;
+
+InfiniFrameWindowBuilder.Create()
+    .SetTitle("Hello")
+    .SetSize(800, 600)
+    .SetStartUrl("https://example.com")
+    .Build()
+    .WaitForClose();
+```
+
+### Chromeless Window
+
+```csharp
+InfiniFrameWindowBuilder.Create()
+    .SetChromeless(true)
+    .SetTransparent(true)
+    .SetSize(1280, 720)
+    .Build();
+```
+
+### Kiosk Mode
+
+```csharp
+InfiniFrameWindowBuilder.Create()
+    .SetFullScreen(true)
+    .SetResizable(false)
+    .SetContextMenuEnabled(false)
+    .SetDevToolsEnabled(false)
+    .SetStartUrl("https://myapp.com")
+    .Build();
+```
+
+## Anti-Patterns
+
+❌ **Never use async Task Main**:
+```csharp
+// WRONG — STA ignored
+async Task Main(string[] args) { ... }
+```
+
+✅ **Use explicit Main with [STAThread]**:
+```csharp
+[STAThread]
+static void Main(string[] args) { ... }
+```
+
+❌ **Never configure after Build**:
+```csharp
+var window = builder.Build();
+window.SetTitle("New Title");  // WRONG — SetTitle is builder-only
+```
+
+✅ **Use runtime API for post-build changes**:
+```csharp
+var window = builder.Build();
+window.Load("https://new-url.com");  // Correct runtime API
+```
+
+❌ **Never call window ops from background thread without Invoke**:
+```csharp
+Task.Run(() => window.Close());  // WRONG — thread affinity violation
+```
+
+✅ **Use Invoke**:
+```csharp
+Task.Run(() => window.Invoke(() => window.Close()));  // Correct
+```

--- a/skills/infiniframe-custom-window-chrome/SKILL.md
+++ b/skills/infiniframe-custom-window-chrome/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: infiniframe-custom-window-chrome
+description: Building custom window title bars, resize handles, and chromeless UIs using InfiniLore.InfiniFrame.Blazor components.
+---
+# InfiniFrame Custom Window Chrome
+
+> Skill for building custom window title bars, resize handles, and chromeless UIs using `InfiniLore.InfiniFrame.Blazor`.
+
+## When to Use This Skill
+
+- Creating chromeless windows (no native title bar)
+- Building custom title bars with Blazor components
+- Implementing custom resize handles
+- Designing modern desktop app UIs
+- Implementing drag-to-move window functionality
+
+## Package
+
+```bash
+dotnet add package InfiniLore.InfiniFrame.Blazor
+```
+
+This is a companion package — typically used with `InfiniLore.InfiniFrame.BlazorWebView` or `InfiniLore.InfiniFrame.WebServer`.
+
+## Enable Chromeless Mode
+
+Remove native OS title bar so Blazor UI is entire window:
+
+```csharp
+builder.WithInfiniFrameWindowBuilder(w => w
+    .SetChromeless(true)
+    .SetTransparent(true)  // Optional: for rounded corners/glassmorphism
+    .SetSize(1280, 720)
+    .Center()
+);
+```
+
+**Windows note**: `SetChromeless(true)` automatically disables `UseOsDefaultLocation`, `UseOsDefaultSize`, and `Resizable`. Set them explicitly after calling `SetChromeless` if needed.
+
+## Components
+
+### InfiniFrameWindowDragArea
+
+Makes any area draggable — acts as window's title bar.
+
+```razor
+<InfiniFrameWindowDragArea>
+    <span>My Application</span>
+</InfiniFrameWindowDragArea>
+```
+
+**Features**:
+- Handles pointer capture automatically
+- Drag operations stable even when cursor moves fast
+- Place at top of layout to create custom drag region
+
+### InfiniFrameWindowButton
+
+Button that performs window action (minimize, maximize, or close):
+
+```razor
+<InfiniFrameWindowButton Action="WindowAction.Minimize" />
+<InfiniFrameWindowButton Action="WindowAction.Maximize" />
+<InfiniFrameWindowButton Action="WindowAction.Close" />
+```
+
+| `WindowAction` | Description |
+|----------------|-------------|
+| `Minimize` | Minimizes window to taskbar |
+| `Maximize` | Maximizes or restores window |
+| `Close` | Closes window and exits application |
+
+Each button styled via `.razor.css` scoped stylesheet — override styles by targeting component's generated class or wrapping in styled container.
+
+### InfiniFrameWindowResizeThumb
+
+Drag handle for resizing from specific edge or corner:
+
+```razor
+<InfiniFrameWindowResizeThumb Origin="ResizeOrigin.BottomRight" />
+```
+
+Available `ResizeOrigin` values:
+- `TopLeft`, `Top`, `TopRight`
+- `Left`, `Right`
+- `BottomLeft`, `Bottom`, `BottomRight`
+
+### InfiniFrameWindowResizeThumbContainer
+
+Renders resize thumbs for ALL edges and corners in single declaration:
+
+```razor
+<InfiniFrameWindowResizeThumbContainer />
+```
+
+**Place at root level** of layout so it covers entire window perimeter.
+
+## Full Layout Example
+
+Complete custom window chrome in Blazor layout:
+
+```razor
+@* MainLayout.razor *@
+@inherits LayoutComponentBase
+
+<div class="window-root">
+
+    <!-- Resize handles on all edges -->
+    <InfiniFrameWindowResizeThumbContainer />
+
+    <!-- Custom title bar -->
+    <div class="titlebar">
+        <InfiniFrameWindowDragArea class="drag-region">
+            <img src="icon.png" alt="App icon" width="16" />
+            <span class="title">My Application</span>
+        </InfiniFrameWindowDragArea>
+
+        <div class="window-buttons">
+            <InfiniFrameWindowButton Action="WindowAction.Minimize" />
+            <InfiniFrameWindowButton Action="WindowAction.Maximize" />
+            <InfiniFrameWindowButton Action="WindowAction.Close" />
+        </div>
+    </div>
+
+    <!-- Page content -->
+    <main class="content">
+        @Body
+    </main>
+
+</div>
+```
+
+```css
+/* MainLayout.razor.css */
+.window-root {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.titlebar {
+    display: flex;
+    align-items: center;
+    height: 32px;
+    background: #1e1e2e;
+    user-select: none;
+}
+
+.drag-region {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 12px;
+    height: 100%;
+}
+
+.window-buttons {
+    display: flex;
+    height: 100%;
+}
+
+.content {
+    flex: 1;
+    overflow: auto;
+}
+```
+
+## JavaScript Interop for Drag Areas
+
+`InfiniLore.InfiniFrame.Js` used internally by drag and resize components to call `setPointerCapture` on underlying DOM element.
+
+If building custom drag components, use `IInfiniFrameJs` directly:
+
+```razor
+@inject IInfiniFrameJs InfiniJs
+
+<div @ref="dragRef" @onpointerdown="OnPointerDown">Drag me</div>
+
+@code {
+    ElementReference dragRef;
+
+    async Task OnPointerDown(PointerEventArgs e) {
+        await InfiniJs.SetPointerCaptureAsync(dragRef, e.PointerId, CancellationToken.None);
+    }
+}
+```
+
+## Styling Tips
+
+### Transparent Resize Thumbs
+
+Resize thumbs are transparent by default — they only respond to pointer events at window edge.
+
+### Transparency Effects
+
+On Windows with `SetTransparent(true)`, CSS `background: transparent` shows through to desktop — enables acrylic or mica-style effects via CSS backdrop.
+
+```csharp
+// In Program.cs
+builder.WithInfiniFrameWindowBuilder(w => w
+    .SetChromeless(true)
+    .SetTransparent(true)
+);
+```
+
+```css
+/* In Blazor component */
+.window-root {
+    background: rgba(30, 30, 46, 0.8);
+    backdrop-filter: blur(10px);
+}
+```
+
+### Double-Click to Maximize
+
+Double-clicking on `InfiniFrameWindowDragArea` does NOT automatically maximize — handle `@ondblclick` yourself:
+
+```razor
+@inject IInfiniFrameWindow Window
+
+<InfiniFrameWindowDragArea @ondblclick="ToggleMaximize">
+    <span>My App</span>
+</InfiniFrameWindowDragArea>
+
+@code {
+    void ToggleMaximize() => Window.Invoke(() => {
+        Window.ToggleMaximized();
+    });
+}
+```
+
+## Common Patterns
+
+### Minimal Title Bar
+
+```razor
+<div class="titlebar">
+    <InfiniFrameWindowDragArea class="drag-area">
+        <span>My App</span>
+    </InfiniFrameWindowDragArea>
+    <InfiniFrameWindowButton Action="WindowAction.Close" />
+</div>
+```
+
+### Custom Styled Buttons
+
+```razor
+<div class="custom-buttons">
+    <InfiniFrameWindowButton Action="WindowAction.Minimize" class="btn-minimize" />
+    <InfiniFrameWindowButton Action="WindowAction.Maximize" class="btn-maximize" />
+    <InfiniFrameWindowButton Action="WindowAction.Close" class="btn-close" />
+</div>
+
+<style>
+.custom-buttons { display: flex; }
+.btn-close:hover { background: #e81123; color: white; }
+.btn-minimize:hover, .btn-maximize:hover { background: rgba(255,255,255,0.1); }
+</style>
+```
+
+### Drag Area with App Icon
+
+```razor
+<InfiniFrameWindowDragArea class="title-drag">
+    <img src="app-icon.svg" class="app-icon" />
+    <span class="app-title">@AppName</span>
+</InfiniFrameWindowDragArea>
+
+<style>
+.title-drag {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 16px;
+    height: 100%;
+}
+.app-icon { width: 16px; height: 16px; }
+.app-title { font-weight: 600; }
+</style>
+```
+
+### Window with Only Resize Thumbs (No Title Bar)
+
+```razor
+<div class="chromeless-root">
+    <InfiniFrameWindowResizeThumbContainer />
+    <main class="content">
+        @Body
+    </main>
+</div>
+
+<style>
+.chromeless-root {
+    height: 100vh;
+    position: relative;
+}
+.content {
+    height: 100%;
+    overflow: auto;
+}
+</style>
+```
+
+## Anti-Patterns
+
+❌ **Forget to enable chromeless mode**:
+```razor
+<!-- WRONG — native title bar will still show -->
+<InfiniFrameWindowDragArea>...</InfiniFrameWindowDragArea>
+```
+
+✅ **Enable chromeless in builder**:
+```csharp
+builder.WithInfiniFrameWindowBuilder(w => w.SetChromeless(true));
+```
+
+❌ **Place resize thumbs inside content area**:
+```razor
+<!-- WRONG — thumbs won't work at window edges -->
+<main>
+    <InfiniFrameWindowResizeThumbContainer />
+</main>
+```
+
+✅ **Place thumbs at root level**:
+```razor
+<div class="root">
+    <InfiniFrameWindowResizeThumbContainer />
+    <main>@Body</main>
+</div>
+```
+
+❌ **Expect double-click to maximize automatically**:
+```razor
+<!-- WRONG -- does nothing on double-click -->
+<InfiniFrameWindowDragArea>Title</InfiniFrameWindowDragArea>
+```
+
+✅ **Handle double-click yourself**:
+```razor
+<InfiniFrameWindowDragArea @ondblclick="ToggleMaximize">Title</InfiniFrameWindowDragArea>
+```

--- a/skills/infiniframe-javascript-interop/SKILL.md
+++ b/skills/infiniframe-javascript-interop/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: infiniframe-javascript-interop
+description: C# to JavaScript communication using InfiniLore.InfiniFrame.Js and web messaging. Versioned envelope, pointer capture, and built-in message handlers.
+---
+# InfiniFrame JavaScript Interop
+
+> Skill for C#↔JavaScript communication using `InfiniLore.InfiniFrame.Js` and web messaging.
+
+## When to Use This Skill
+
+- Sending messages between C# and JavaScript
+- Implementing custom window management from JS
+- Pointer capture for drag operations
+- Building custom interop components
+- Exchanging structured data between layers
+
+## Packages
+
+### Core Messaging (included in all packages)
+Web messaging is available in all InfiniFrame integrations — no additional package needed.
+
+### InfiniFrame.Js (Blazor-specific)
+```bash
+dotnet add package InfiniLore.InfiniFrame.Js
+```
+
+Automatically included by `InfiniLore.InfiniFrame.BlazorWebView`.
+
+## Web Messaging Protocol
+
+### Message Envelope (MANDATORY)
+
+All JavaScript→C# messages MUST use this JSON format:
+
+```json
+{
+  "id": "<string>",
+  "data": <any>,
+  "version": 1,
+  "channel": "<optional-string>"
+}
+```
+
+**Required fields**: `id`, `version` (must be `1`)
+**Optional fields**: `data`, `channel`
+
+**Legacy format out of support**: `id;payload` is NOT supported.
+
+## Sending Messages
+
+### C# → JavaScript
+
+```csharp
+// Sync
+window.SendWebMessage("hello from C#");
+
+// Async
+await window.SendWebMessageAsync("async hello");
+
+// Structured data
+window.SendWebMessage(JsonSerializer.Serialize(new {
+    id = "update",
+    data = new { count = 42 },
+    version = 1
+}));
+```
+
+JavaScript receiver:
+
+```js
+window.infiniframe.host.receiveMessage(function(message) {
+    console.log("Received from C#:", message);
+    
+    // Parse if it's structured data
+    const envelope = JSON.parse(message);
+    if (envelope.id === "update") {
+        updateUI(envelope.data.count);
+    }
+});
+```
+
+### JavaScript → C#
+
+JavaScript (MUST use envelope):
+
+```js
+// Simple message
+window.infiniframe.host.postMessage({ 
+    id: "action", 
+    data: 42, 
+    version: 1 
+});
+
+// Structured data
+window.infiniframe.host.postMessage({
+    id: "log",
+    data: { message: "hello from JS", level: "info" },
+    version: 1
+});
+```
+
+C# raw handler:
+
+```csharp
+builder.Events.WebMessageReceived.Add(raw => {
+    var msg = JsonSerializer.Deserialize<MyMessage>(raw);
+    Console.WriteLine($"From JS: {msg}");
+});
+```
+
+C# named handler:
+
+```csharp
+builder.MessageHandlers.RegisterMessageHandler("action", (window, payload) => {
+    Console.WriteLine($"Action triggered with: {payload}");
+});
+
+builder.MessageHandlers.RegisterMessageHandler("log", (window, payload) => {
+    using var doc = JsonDocument.Parse(payload!);
+    string? message = doc.RootElement.GetProperty("message").GetString();
+    string? level = doc.RootElement.GetProperty("level").GetString();
+    Console.WriteLine($"[{level}] {message}");
+});
+```
+
+## Built-in JavaScript Message Handlers
+
+`InfiniFrame.Js` registers handlers for window management from JavaScript.
+
+### Including the Script
+
+```html
+<script src="_content/InfiniLore.InfiniFrame.Js/InfiniFrame.js"></script>
+```
+
+### Available Handlers
+
+| Handler ID | What it does |
+|------------|--------------|
+| `__infiniframe:window:minimize` | Minimize window |
+| `__infiniframe:window:maximize` | Maximize/restore window |
+| `__infiniframe:window:close` | Close window |
+| `__infiniframe:fullscreen:enter` | Enter fullscreen |
+| `__infiniframe:fullscreen:exit` | Exit fullscreen |
+| `__infiniframe:title:change` | Update native window title |
+| `__infiniframe:open:external` | Open links in default browser |
+
+### Using from Custom JavaScript
+
+```js
+// Window actions
+window.infiniframe.host.postMessage({ 
+    id: "__infiniframe:window:minimize", 
+    data: null, 
+    version: 1 
+});
+
+window.infiniframe.host.postMessage({ 
+    id: "__infiniframe:window:close", 
+    data: null, 
+    version: 1 
+});
+
+// Title change (data = new title string)
+window.infiniframe.host.postMessage({ 
+    id: "__infiniframe:title:change", 
+    data: "New Window Title", 
+    version: 1 
+});
+
+// Fullscreen
+window.infiniframe.host.postMessage({ 
+    id: "__infiniframe:fullscreen:enter", 
+    data: null, 
+    version: 1 
+});
+```
+
+### Using InfiniFrame.js API
+
+If `InfiniFrame.js` script is included:
+
+```js
+window.infiniFrame.HostMessaging.sendMessageToHost("__infiniframe:window:minimize");
+window.infiniFrame.HostMessaging.sendMessageToHost("__infiniframe:title:change", "New Title");
+```
+
+These are used internally by `InfiniFrameWindowDragArea`, `InfiniFrameWindowButton`, and related components.
+
+## IInfiniFrameJs (Blazor-Specific)
+
+### DI Registration
+
+Auto-registered when using `BlazorWebView`. For core package only:
+
+```csharp
+services.AddInfiniFrameJs();
+```
+
+### API
+
+```csharp
+public interface IInfiniFrameJs {
+    Task SetPointerCaptureAsync(ElementReference element, long pointerId, CancellationToken ct);
+    Task ReleasePointerCaptureAsync(ElementReference element, long pointerId, CancellationToken ct);
+}
+```
+
+Wraps browser's `element.setPointerCapture()` / `element.releasePointerCapture()` for reliable drag interactions.
+
+### Usage in Blazor Components
+
+```razor
+@inject IInfiniFrameJs InfiniJs
+
+<div @ref="handle"
+     @onpointerdown="StartDrag"
+     @onpointermove="OnDrag"
+     @onpointerup="EndDrag">
+    Drag me
+</div>
+
+@code {
+    ElementReference handle;
+    bool isDragging;
+
+    async Task StartDrag(PointerEventArgs e) {
+        await InfiniJs.SetPointerCaptureAsync(handle, e.PointerId, default);
+        isDragging = true;
+    }
+
+    async Task OnDrag(PointerEventArgs e) {
+        if (!isDragging) return;
+        // Handle drag
+    }
+
+    async Task EndDrag(PointerEventArgs e) {
+        await InfiniJs.ReleasePointerCaptureAsync(handle, e.PointerId, default);
+        isDragging = false;
+    }
+}
+```
+
+**Why pointer capture is needed**: Keeps events flowing to element even after pointer leaves it — necessary for stable drag operations.
+
+## Exchanging Structured Data
+
+### C# → JS Pattern
+
+C# sender:
+```csharp
+window.SendWebMessage(JsonSerializer.Serialize(new {
+    id = "user:update",
+    data = new { 
+        name = "John", 
+        email = "john@example.com",
+        roles = new[] { "admin", "user" }
+    },
+    version = 1
+}));
+```
+
+JavaScript receiver:
+```js
+window.infiniframe.host.receiveMessage(function(raw) {
+    const envelope = JSON.parse(raw);
+    
+    if (envelope.id === "user:update") {
+        const { name, email, roles } = envelope.data;
+        updateUserDisplay(name, email, roles);
+    }
+});
+```
+
+### JS → C# Pattern
+
+JavaScript sender:
+```js
+window.infiniframe.host.postMessage({
+    id: "form:submit",
+    data: {
+        username: "john",
+        action: "login"
+    },
+    version: 1
+});
+```
+
+C# receiver (named handler):
+```csharp
+builder.MessageHandlers.RegisterMessageHandler("form:submit", (window, payload) => {
+    using var doc = JsonDocument.Parse(payload!);
+    string? username = doc.RootElement.GetProperty("username").GetString();
+    string? action = doc.RootElement.GetProperty("action").GetString();
+    
+    // Handle form submission
+    HandleLogin(username, action);
+});
+```
+
+C# receiver (raw handler):
+```csharp
+builder.Events.WebMessageReceived.Add(raw => {
+    using var doc = JsonDocument.Parse(raw);
+    string? id = doc.RootElement.GetProperty("id").GetString();
+    
+    if (id == "form:submit") {
+        var data = doc.RootElement.GetProperty("data");
+        // Process data
+    }
+});
+```
+
+## Common Patterns
+
+### Request-Response Pattern
+
+C# registers handler:
+```csharp
+builder.MessageHandlers.RegisterMessageHandler("app:ping", (window, _) => {
+    window.SendWebMessage(JsonSerializer.Serialize(new {
+        id = "app:pong",
+        data = new { timestamp = DateTime.UtcNow },
+        version = 1
+    }));
+});
+```
+
+JavaScript sends and receives:
+```js
+window.infiniframe.host.receiveMessage(function(raw) {
+    const envelope = JSON.parse(raw);
+    if (envelope.id === "app:pong") {
+        console.log("Pong received at:", envelope.data.timestamp);
+    }
+});
+
+window.infiniframe.host.postMessage({
+    id: "app:ping",
+    data: null,
+    version: 1
+});
+```
+
+### Event Streaming Pattern
+
+C# pushes updates:
+```csharp
+async Task StreamUpdates(IInfiniFrameWindow window, CancellationToken ct) {
+    while (!ct.IsCancellationRequested) {
+        var data = await FetchUpdateAsync();
+        window.SendWebMessage(JsonSerializer.Serialize(new {
+            id = "update:data",
+            data = data,
+            version = 1
+        }));
+        await Task.Delay(1000, ct);
+    }
+}
+```
+
+JavaScript consumes:
+```js
+window.infiniframe.host.receiveMessage(function(raw) {
+    const envelope = JSON.parse(raw);
+    if (envelope.id === "update:data") {
+        renderChart(envelope.data);
+    }
+});
+```
+
+## Anti-Patterns
+
+❌ **Send raw string without envelope**:
+```js
+// WRONG — C# won't parse it correctly
+window.infiniframe.host.postMessage("hello");
+```
+
+✅ **Always use envelope**:
+```js
+window.infiniframe.host.postMessage({ id: "greeting", data: "hello", version: 1 });
+```
+
+❌ **Use wrong version**:
+```js
+// WRONG — version must be 1
+window.infiniframe.host.postMessage({ id: "action", data: null, version: 2 });
+```
+
+✅ **Use version 1**:
+```js
+window.infiniframe.host.postMessage({ id: "action", data: null, version: 1 });
+```
+
+❌ **Forget pointer capture for drags**:
+```razor
+// WRONG — drag breaks when cursor leaves element
+<div @onpointerdown="StartDrag" @onpointermove="OnDrag">
+```
+
+✅ **Use pointer capture**:
+```razor
+async Task StartDrag(PointerEventArgs e) {
+    await InfiniJs.SetPointerCaptureAsync(handle, e.PointerId, default);
+}
+```
+
+## Examples
+
+- https://github.com/InfiniLore/InfiniFrame/tree/master/examples/InfiniFrameExample.WebApp.Vue — Registers all built-in message handlers
+- https://github.com/InfiniLore/InfiniFrame/tree/master/examples/InfiniFrameExample.WebApp.React — Custom scheme handler returning dynamic JS, two-way messaging

--- a/skills/infiniframe-native-cpp-api/SKILL.md
+++ b/skills/infiniframe-native-cpp-api/SKILL.md
@@ -1,0 +1,349 @@
+---
+name: infiniframe-native-cpp-api
+description: Extending InfiniFrame at the native C++ layer. Pimpl idiom, C ABI exports, P/Invoke, string ownership, and platform implementations.
+---
+# InfiniFrame Native C++ API
+
+> Skill for extending InfiniFrame at the native C++ layer or calling native DLLs directly.
+
+## When to Use This Skill
+
+- Extending InfiniFrame native functionality
+- Building custom platform-specific features
+- Debugging native interop issues
+- Understanding C ABI exports
+- Working with P/Invoke bindings
+
+## Architecture Overview
+
+### Pimpl Idiom
+
+InfiniFrame uses [Pimpl idiom](https://en.cppreference.com/w/cpp/language/pimpl.html) throughout:
+- `struct Impl` held by `std::unique_ptr<Impl>`
+- Defined per-platform in `.cpp`/`.mm` files
+- Headers are entirely platform-agnostic
+
+### File Structure
+
+```
+src/InfiniFrame.Native/
+├── Core/
+│   ├── InfiniFrame.h           # Top-level native interop include
+│   ├── InfiniFrameWindow.h     # Main native window class and callbacks
+│   ├── InfiniFrameDialog.h     # Dialog surface for file/folder/message dialogs
+│   ├── InfiniFrameInitParams.h # Build-time and startup window parameters
+│   └── InfiniFrameWindowImpl.h # Shared implementation state for platform windows
+├── Types/
+│   ├── Basic.h                 # Primitive and interop-safe aliases
+│   ├── Dialog.h                # Dialog enums and result contracts
+│   └── Callbacks.h             # Callback signatures used by interop exports
+├── Utils/
+│   └── Event.h                 # Event helper abstraction
+├── Platform/
+│   ├── Windows/                # Win32 + WebView2 implementation
+│   │   └── Window.cpp
+│   ├── Mac/                    # Cocoa/WKWebView implementation
+│   │   ├── Window.mm
+│   │   ├── AppDelegate.mm
+│   │   ├── UiDelegate.mm
+│   │   ├── WindowDelegate.mm
+│   │   ├── NavigationDelegate.mm
+│   │   ├── UrlSchemeHandler.mm
+│   │   └── NSWindowBorderless.mm
+│   └── Linux/                  # GTK/WebKitGTK implementation
+│       └── Window.cpp
+└── Exports.cpp                 # Exported C ABI used by managed layer
+```
+
+## Core Headers
+
+### InfiniFrame.h
+
+Top-level native interop include. Use this header for:
+- Basic type definitions
+- Interop constants
+- Common utility functions
+
+### InfiniFrameWindow.h
+
+Main native window class and callbacks. Contains:
+- `InfiniFrameWindow` class declaration
+- Window callback types
+- Public API for window operations
+
+### InfiniFrameDialog.h
+
+Dialog surface for native OS dialogs:
+- File picker dialogs
+- Folder picker dialogs
+- Message box dialogs
+- Dialog enums and result types
+
+### InfiniFrameInitParams.h
+
+Build-time and startup window parameters:
+- `InfiniFrameInitParams` struct
+- Configuration flags
+- Platform-specific init options
+
+### InfiniFrameWindowImpl.h
+
+Shared implementation state:
+- Platform-agnostic window state
+- Shared between all platform implementations
+
+## Shared Native Types
+
+### Basic.h
+
+Primitive and interop-safe aliases:
+- String types
+- Numeric types
+- Boolean types
+- Handle types
+
+### Dialog.h
+
+Dialog enums and result contracts:
+- Button configurations
+- Icon types
+- Result values
+
+### Callbacks.h
+
+Callback signatures used by interop exports:
+- Function pointer types
+- Delegate signatures
+- Event handler types
+
+### Event.h
+
+Event helper abstraction:
+- Multi-subscriber event handling
+- Ordered event execution
+- Event registration management
+
+## Platform Implementations
+
+### Windows (Platform/Windows/*)
+
+- Win32 API for window management
+- WebView2 for browser control
+- COM-based WebView2 integration
+- Native menu and dialog support
+
+### macOS (Platform/Mac/*)
+
+- Cocoa for window management
+- WKWebView for browser control
+- Objective-C++ (`.mm`) files
+- Separate delegate files for:
+  - `AppDelegate` — application lifecycle
+  - `UiDelegate` — UI delegate for WebView
+  - `WindowDelegate` — window events
+  - `NavigationDelegate` — navigation events
+  - `UrlSchemeHandler` — custom scheme handling
+  - `NSWindowBorderless` — chromeless window support
+
+### Linux (Platform/Linux/*)
+
+- GTK3 for window management
+- WebKitGTK for browser control
+- GTK signal-based event handling
+
+## Exported Bridge (Exports.cpp)
+
+C ABI exports used by managed layer:
+- All functions prefixed with `InfiniFrame_`
+- C linkage (`extern "C"`)
+- Platform-independent signatures
+
+### String Ownership
+
+**CRITICAL**: InfiniFrame exports explicit free functions for strings returned from native layer:
+
+```csharp
+InfiniFrame_FreeString(ptr);
+InfiniFrame_FreeStringArray(ptr, count);
+```
+
+These are called automatically by managed wrapper — but if calling native exports directly, you are responsible for invoking them.
+
+**Failure to free returned strings = memory leaks in long-running applications.**
+
+## Build System
+
+### CMake 4.0
+
+```bash
+# Build
+cmake -B build -S .
+cmake --build build --config Release
+```
+
+### C++ Standard
+
+- **C++23** required
+- Uses `std::format` (not external formatting library)
+- Uses `simdjson` via CMake FetchContent (not bundled nlohmann/json)
+- Uses `simdutf` for UTF conversions (not custom ToWide/ToUTF8String)
+
+### Sanitizers (Debug)
+
+- AddressSanitizer (ASan)
+- UndefinedBehaviorSanitizer (UBSan)
+- LeakSanitizer enabled
+
+## P/Invoke Generation
+
+InfiniFrame uses source-generated `[LibraryImport]` (requires .NET 7+):
+
+```csharp
+// Modern approach (InfiniFrame)
+[LibraryImport("InfiniFrame.Native", ...)]
+static partial void InfiniFrame_SetTitle(IntPtr instance, ...);
+```
+
+Not manual `[DllImport]` (old Photino approach):
+```csharp
+// Old approach (Photino) — NOT used in InfiniFrame
+[DllImport("Photino.Native", ...)]
+static extern void Photino_SetTitle(IntPtr instance, string title);
+```
+
+## String Conversions
+
+All UTF-8 ↔ UTF-16 conversions use `simdutf`:
+- High-performance
+- Validated for correctness
+- No silent corruption of non-ASCII paths (fixed from Photino #163)
+
+## Native DLL Direct Calls
+
+If calling native exports directly (bypassing managed wrapper):
+
+### Function Naming
+
+All exports prefixed with `InfiniFrame_`:
+- `InfiniFrame_SetTitle`
+- `InfiniFrame_GetTitle`
+- `InfiniFrame_ShowMessage`
+- `InfiniFrame_ShowSaveFile` (note: gained `defaultFileName` parameter vs Photino)
+
+### String Return Ownership
+
+```csharp
+// If native function returns char*, you MUST free it
+IntPtr titlePtr = InfiniFrame_GetTitle(windowHandle);
+string title = Marshal.PtrToStringAnsi(titlePtr);
+InfiniFrame_FreeString(titlePtr);  // MANDATORY
+```
+
+### Array Return Ownership
+
+```csharp
+// If native function returns string array
+IntPtr arrayPtr = InfiniFrame_GetMonitors(windowHandle, out int count);
+// ... use array ...
+InfiniFrame_FreeStringArray(arrayPtr, count);  // MANDATORY
+```
+
+## Extending InfiniFrame Natively
+
+### Adding Platform-Specific Code
+
+1. Create files under `Platform/<PlatformName>/`
+2. Implement platform-specific logic in `.cpp` (or `.mm` for macOS)
+3. Use Pimpl idiom — keep headers platform-agnostic
+4. Add exports to `Exports.cpp` if managed layer needs access
+
+### Adding New Exports
+
+1. Define callback signatures in `Types/Callbacks.h`
+2. Implement function in platform-specific `.cpp`
+3. Export via `Exports.cpp` with `InfiniFrame_` prefix
+4. Add managed wrapper in C# with `[LibraryImport]`
+5. Add explicit free function if returning strings
+
+### Example: Adding New Window Method
+
+**Exports.cpp**:
+```cpp
+extern "C" INFINIFRAME_API void InfiniFrame_MyNewMethod(InfWindow* instance, int param) {
+    instance->Impl->MyNewMethod(param);
+}
+```
+
+**C# wrapper**:
+```csharp
+[LibraryImport("InfiniFrame.Native")]
+static partial void InfiniFrame_MyNewMethod(IntPtr instance, int param);
+```
+
+## Known Issues Fixed from Photino
+
+| Photino Issue | How InfiniFrame Fixed It |
+|---------------|--------------------------|
+| Custom scheme handlers broken on Windows (#173/174) | Rewritten registration path, tested end-to-end |
+| Memory leak in SendWebMessage (#165) | Explicit InfiniFrame_FreeString ownership model |
+| No programmatic window focus (#158) | InfiniFrame_SetFocused/GetFocused exported |
+| UTF encoding bug corrupts non-ASCII paths (#163) | simdutf used for all conversions |
+| Stack overflow in WaitForExit on Linux (#141) | Per-window independent message loops |
+| SetTopmost uses wrong Win32 style (#175) | Fixed HWND_TOPMOST/HWND_NOTOPMOST usage |
+
+## Code Style
+
+- **K&R brace style** (enforced by https://github.com/InfiniLore/InfiniFrame/blob/master/.clang-format)
+- **C++23** features (`std::format`, etc.)
+- **Pimpl idiom** throughout
+- **Platform-agnostic headers**, platform-specific implementations
+
+Run `clang-format` with repo configuration when editing native sources:
+
+```bash
+clang-format -i src/InfiniFrame.Native/**/*.cpp
+clang-format -i src/InfiniFrame.Native/**/*.h
+```
+
+## Anti-Patterns
+
+❌ **Include platform headers in core headers**:
+```cpp
+// WRONG in InfiniFrameWindow.h — breaks cross-platform build
+#include <windows.h>
+#include <gtk/gtk.h>
+```
+
+✅ **Keep headers platform-agnostic**:
+```cpp
+// Correct — implementation details in .cpp files
+struct Impl;
+std::unique_ptr<Impl> _impl;
+```
+
+❌ **Forget to free native strings**:
+```csharp
+// WRONG — memory leak
+IntPtr str = InfiniFrame_GetTitle(handle);
+string title = Marshal.PtrToStringAnsi(str);
+// InfiniFrame_FreeString(str); // MISSING
+```
+
+✅ **Always free returned strings**:
+```csharp
+IntPtr str = InfiniFrame_GetTitle(handle);
+string title = Marshal.PtrToStringAnsi(str);
+InfiniFrame_FreeString(str);  // MANDATORY
+```
+
+❌ **Use bundled JSON headers**:
+```cpp
+// WRONG — Photino approach
+#include "json.hpp"
+```
+
+✅ **Use simdjson via FetchContent**:
+```cpp
+// Correct — InfiniFrame approach
+#include <simdjson.h>
+```

--- a/skills/infiniframe-packaging-tool/SKILL.md
+++ b/skills/infiniframe-packaging-tool/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: infiniframe-packaging-tool
+description: Packaging InfiniFrame applications into single-file executables using InfiniLore.InfiniFrame.Tools.Pack. CLI usage, bootstrap, and fallback policy.
+---
+# InfiniFrame Packaging Tool
+
+> Skill for packaging InfiniFrame applications into single-file executables using `InfiniLore.InfiniFrame.Tools.Pack`.
+
+## When to Use This Skill
+
+- Publishing single-file distributable apps
+- Embedding native InfiniFrame binaries
+- Embedding wwwroot content
+- CI/CD pipeline for app distribution
+- Multi-platform packaging (Windows, Linux, macOS)
+
+## Package
+
+```bash
+# Install from NuGet
+dotnet tool install --global InfiniLore.InfiniFrame.Tools.Pack
+
+# Or build from source (repo root)
+.\src\InfiniFrame.Tools.Pack\install-or-update-pack-tool.ps1
+```
+
+## What It Does
+
+Packages InfiniFrame app into single-file executable by embedding:
+- `wwwroot` content
+- Native InfiniFrame runtime binaries for selected RID
+
+### How It Works
+
+1. Parse CLI options and resolve defaults
+2. Resolve native runtime artifacts from preflight `dotnet publish`
+3. Run `dotnet publish` in single-file mode with custom MSBuild targets
+4. Remove unpacked runtime files from publish folder
+
+**Native files embedded as resources** — app MUST initialize with `InfiniFrameSingleFileBootstrap.Initialize()`.
+
+## Command Syntax
+
+```bash
+dotnet tool run infiniframe-pack publish <project.csproj> [options]
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--rid <RID\|auto>` | `auto` | Target runtime identifier |
+| `--configuration <Config>` | `Release` | Build configuration |
+| `--framework <TFM>` | TargetFramework or first TargetFrameworks | Target framework |
+| `--self-contained <true\|false>` | `true` | Self-contained publish mode |
+| `--output <path>` | `bin/<Config>/<TFM>/<RID>/publish` | Output directory |
+| `--no-restore` | — | Skip restore during publish |
+| `--verbose` | — | Normal verbosity for publish |
+| `--force-clean-output` | — | Allow recursive deletion of non-default outputs |
+| `--native-artifacts-fallback <path>` | — | Explicit fallback native artifact directory |
+| `--allow-stale-native-fallback` | — | Permit fallback artifacts when preflight fails |
+
+### Environment Overrides
+
+```bash
+INFINIFRAME_PACK_NATIVE_ARTIFACT_FALLBACK=<path>
+INFINIFRAME_PACK_ALLOW_STALE_NATIVE_FALLBACK=true|false
+```
+
+## Usage Examples
+
+### Basic Publish with Defaults
+
+```bash
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj
+```
+
+### Publish for Specific Runtime
+
+```bash
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj --rid win-x64
+```
+
+### Multi-Targeted App, Choose Framework
+
+```bash
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj --framework net10.0
+```
+
+### Custom Output and Faster Inner-Loop
+
+```bash
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj \
+  --configuration Debug \
+  --no-restore \
+  --output artifacts/publish/MyApp-win-x64 \
+  --verbose
+```
+
+### CI-Friendly Deterministic Output
+
+```bash
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj \
+  --output artifacts/publish/MyApp
+```
+
+### Multi-RID Packaging
+
+Run once per RID with separate outputs:
+
+```bash
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj --rid win-x64 --output artifacts/publish/MyApp-win-x64
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj --rid linux-x64 --output artifacts/publish/MyApp-linux-x64
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj --rid osx-arm64 --output artifacts/publish/MyApp-osx-arm64
+```
+
+### Prefer Explicit --framework for Multi-Targeting
+
+```bash
+# If project uses TargetFrameworks, pass --framework explicitly
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj --framework net9.0
+```
+
+## App Bootstrap Requirement
+
+**After packaging**, initialize single-file bootstrap before creating window:
+
+```csharp
+using InfiniFrame;
+
+public static class Program {
+    [STAThread]
+    public static void Main(string[] args) {
+        InfiniFrameSingleFileBootstrap.Initialize();
+
+        var window = InfiniFrameWindowBuilder.Create()
+            .SetTitle("My App")
+            .SetSize(1280, 720)
+            .Center()
+            .Build();
+
+        window.WaitForClose();
+    }
+}
+```
+
+### Why This Is Required
+
+- `infiniframe-pack publish` embeds `InfiniFrame.Native` and platform loader files (`WebView2Loader.dll` on Windows) as resources
+- `InfiniFrameSingleFileBootstrap.Initialize()` extracts them to temporary RID-specific folder
+- Registers native resolver so P/Invoke can load them
+
+**`Initialize()` is idempotent and safe to call once at startup.**
+
+## MSBuild Integration
+
+If project runs packaging from MSBuild target (e.g., with `$(InfiniFramePackCommand)`), tool command must be available on machine.
+
+### Post-Build Packaging
+
+```xml
+<PropertyGroup>
+  <InfiniFramePackCommand>dotnet tool run infiniframe-pack</InfiniFramePackCommand>
+  <InfiniFramePackAfterBuild>true</InfiniFramePackAfterBuild>
+</PropertyGroup>
+```
+
+See https://github.com/InfiniLore/InfiniFrame/tree/master/examples/InfiniFrameExample.SingleFileExe for complete example.
+
+## Native Artifact Fallback Policy
+
+**Fail-fast by default, repo-agnostic by default.**
+
+### Normal Flow
+
+1. Runs preflight publish
+2. Validates native artifacts from that output
+3. If validation fails → packaging fails
+
+### Fallback Flow
+
+When you need fallback artifacts:
+
+1. Provide explicit path with `--native-artifacts-fallback <path>`
+2. Explicitly allow stale fallback use with `--allow-stale-native-fallback`
+
+### Risk Model
+
+- Fallback artifacts treated as potentially stale
+- Fallback usage requires explicit operator opt-in
+- Without explicit stale opt-in, tool exits with error even when fallback exists
+
+## Edge Cases and Pitfalls
+
+### Exit Codes
+
+| Exit Code | Meaning |
+|-----------|---------|
+| `0` | Success |
+| `2` | Native dependency missing (prefail validation failed) |
+| Non-zero | Other errors |
+
+### RID Auto-Detection
+
+`--rid auto` only supports:
+- Current OS
+- `x64` or `arm64` architectures
+
+Other architectures → platform-not-supported error.
+
+### Output Folder Cleaning
+
+Existing output folders deleted before publish. By default, only project-local `bin/...` outputs allowed to be cleaned. Use `--force-clean-output` for custom output folders.
+
+### Multi-Targeting
+
+If project defines `TargetFrameworks` and omit `--framework`, first framework entry is used.
+
+### Self-Contained Parsing
+
+`--self-contained` must be `true` or `false` (case-insensitive boolean parsing).
+
+### Main Executable Validation
+
+If final output does not contain expected main single-file executable, tool exits with non-zero code.
+
+## Installation Methods
+
+### Global Install (NuGet)
+
+```bash
+dotnet tool install --global InfiniLore.InfiniFrame.Tools.Pack
+infiniframe-pack --help
+```
+
+### Update or Uninstall
+
+```bash
+dotnet tool update --global InfiniLore.InfiniFrame.Tools.Pack
+dotnet tool uninstall --global InfiniLore.InfiniFrame.Tools.Pack
+```
+
+### Local Install from Source
+
+```bash
+dotnet pack src/InfiniFrame.Tools.Pack/InfiniFrame.Tools.Pack.csproj -c Release
+dotnet tool install --local --add-source ./src/InfiniFrame.Tools.Pack/bin/Release InfiniLore.InfiniFrame.Tools.Pack
+```
+
+Run with:
+```bash
+dotnet tool run infiniframe-pack --help
+```
+
+### Repo Development Install
+
+```powershell
+# PowerShell
+.\src\InfiniFrame.Tools.Pack\install-or-update-pack-tool.ps1
+```
+
+```bash
+# Bash
+bash ./src/InfiniFrame.Tools.Pack/install-or-update-pack-tool.sh
+```
+
+### Manual Global Install from Source
+
+```bash
+dotnet pack src/InfiniFrame.Tools.Pack/InfiniFrame.Tools.Pack.csproj -c Release
+dotnet tool install --global --add-source ./src/InfiniFrame.Tools.Pack/bin/Release InfiniLore.InfiniFrame.Tools.Pack
+```
+
+## Common Patterns
+
+### CI/CD Pipeline
+
+```yaml
+# GitHub Actions example
+- name: Package Windows
+  run: dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj --rid win-x64 --output artifacts/win-x64
+
+- name: Package Linux
+  run: dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj --rid linux-x64 --output artifacts/linux-x64
+```
+
+### Debug Build for Testing
+
+```bash
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj \
+  --configuration Debug \
+  --output artifacts/debug
+```
+
+### Clean Output Before Publish
+
+```bash
+dotnet tool run infiniframe-pack publish src/MyApp/MyApp.csproj \
+  --force-clean-output \
+  --output custom/output/path
+```
+
+## Anti-Patterns
+
+❌ **Forget bootstrap initialization**:
+```csharp
+// WRONG — native binaries won't be found
+var window = InfiniFrameWindowBuilder.Create().Build();
+```
+
+✅ **Always initialize bootstrap for packaged apps**:
+```csharp
+InfiniFrameSingleFileBootstrap.Initialize();
+var window = InfiniFrameWindowBuilder.Create().Build();
+```
+
+❌ **Use --rid auto for unsupported architectures**:
+```bash
+# WRONG — linux-arm not supported by auto-detection
+dotnet tool run infiniframe-pack publish MyApp.csproj --rid linux-arm
+```
+
+✅ **Specify RID explicitly**:
+```bash
+dotnet tool run infiniframe-pack publish MyApp.csproj --rid linux-arm --native-artifacts-fallback path/to/artifacts
+```
+
+❌ **Allow stale fallback without explicit path**:
+```bash
+# WRONG — will fail without explicit fallback path
+dotnet tool run infiniframe-pack publish MyApp.csproj --allow-stale-native-fallback
+```
+
+✅ **Provide both path and stale permission**:
+```bash
+dotnet tool run infiniframe-pack publish MyApp.csproj \
+  --native-artifacts-fallback artifacts/native \
+  --allow-stale-native-fallback
+```
+
+❌ **Run packaging without native binaries in preflight**:
+```bash
+# WRONG — preflight will fail if natives not present
+dotnet tool run infiniframe-pack publish MyApp.csproj
+```
+
+✅ **Ensure native artifacts present before packaging**:
+```bash
+# First ensure natives are built/present
+dotnet publish MyApp.csproj -r win-x64
+# Then package
+dotnet tool run infiniframe-pack publish MyApp.csproj --rid win-x64
+```

--- a/skills/infiniframe-photino-migration/SKILL.md
+++ b/skills/infiniframe-photino-migration/SKILL.md
@@ -1,0 +1,378 @@
+---
+name: infiniframe-photino-migration
+description: Migrating applications from Photino.NET/Photino.Native to InfiniFrame. API mapping, behavioral changes, event system migration, messaging protocol upgrade, and step-by-step migration guide.
+---
+# InfiniFrame Photino Migration
+
+> Skill for migrating Photino.NET and Photino.Native applications to InfiniFrame. Covers all breaking changes, API mappings, and migration patterns.
+
+## When to Use This Skill
+
+- Migrating existing Photino apps to InfiniFrame
+- Understanding API differences between Photino and InfiniFrame
+- Resolving breaking changes after package update
+- Converting event handlers from Photino to InfiniFrame
+- Upgrading messaging protocol from raw strings to JSON envelope
+- Updating native P/Invoke signatures
+
+## Package Change
+
+| Aspect | Photino | InfiniFrame |
+|--------|---------|-------------|
+| NuGet package | `Photino.NET` | `InfiniLore.InfiniFrame` |
+| Namespace | `Photino.NET` | `InfiniFrame` |
+| Native DLL | `Photino.Native` | `InfiniFrame.Native` |
+| C++ class | `Photino` | `InfiniFrameWindow` |
+| Init params | `PhotinoInitParams` | `InfiniFrameInitParams` |
+| Export prefix | `Photino_` | `InfiniFrame_` |
+
+## Entry Point Migration
+
+### Photino Pattern (BEFORE)
+
+```csharp
+var window = new PhotinoWindow()
+    .SetTitle("My App")
+    .SetDevToolsEnabled(true)
+    .Load(new Uri("https://example.com"));
+window.WaitForClose();
+```
+
+### InfiniFrame Pattern (AFTER)
+
+```csharp
+var window = InfiniFrameWindowBuilder.Create()
+    .SetTitle("My App")
+    .SetDevToolsEnabled(true)
+    .SetStartUrl("https://example.com")
+    .Build();
+window.WaitForClose();
+```
+
+**Critical**: All configuration MUST happen before `Build()`. Runtime configuration is done through the window interface methods.
+
+## API Mapping Table
+
+### Window Construction
+
+| Photino | InfiniFrame | Notes |
+|---------|-------------|-------|
+| `new PhotinoWindow()` | `InfiniFrameWindowBuilder.Create()` | Builder pattern |
+| `new PhotinoWindow(parent)` | `builder.SetParent(parent).Build()` | Parent via builder |
+| `.Load(url)` (initial) | `.SetStartUrl(url)` | Pre-build only |
+| `.LoadRawString(html)` (initial) | `.SetStartString(html)` | Pre-build only |
+| `.Center()` (initial) | `.Center()` | Pre-build only |
+
+### Runtime Window API
+
+| Photino | InfiniFrame | Notes |
+|---------|-------------|-------|
+| `.Load(url)` (runtime) | `.Load(url)` | Same, runtime available |
+| `.LoadRawString(html)` (runtime) | `.LoadRawString(html)` | Same, runtime available |
+| `.Center()` (runtime) | `.Center()` / `.CenterOnCurrentMonitor()` / `.CenterOnMonitor(int)` | Enhanced |
+| `.MoveTo(Point, bool)` | `.SetLocation(x, y)` | Simplified |
+| `.Offset(Point)` | `.Offset(x, y)` | Simplified |
+| `.SetMinHeight(h)` / `.SetMinWidth(w)` | `.SetMinSize(w, h)` | Consolidated |
+| `.SetMaxHeight(h)` / `.SetMaxWidth(w)` | `.SetMaxSize(w, h)` | Consolidated |
+| `.SetLogVerbosity(int)` | **Removed** | Use `ILogger` via DI |
+| `.Win32SetWebView2Path(string)` | **Internal** | Not public |
+| `.WaitForClose()` | `.WaitForClose()` / `.WaitForCloseAsync()` | Async added |
+| `Monitor` struct | `InfiniMonitor` record | Type renamed |
+| `IReadOnlyList<Monitor>` | `ImmutableArray<InfiniMonitor>` | Collection type changed |
+| `PhotinoDialogButtons` | `InfiniFrameDialogButtons` | Enum renamed |
+| `PhotinoDialogResult` | `InfiniFrameDialogResult` | Enum renamed |
+| `PhotinoDialogIcon` | `InfiniFrameDialogIcon` | Enum renamed |
+| `ShowSaveFile(title, path, filters, count)` | `ShowSaveFile(title, path, filters, count, defaultFileName)` | Added parameter |
+
+### Removed APIs (No Replacement)
+
+| Photino API | Reason |
+|-------------|--------|
+| `MacOsVersion` (static) | Internal |
+| `IsWindowsPlatform` / `IsMacOsPlatform` / `IsLinuxPlatform` | Internal |
+| `UseOsDefaultLocation` / `UseOsDefaultSize` (runtime) | Builder/config time only |
+| `BrowserControlInitParameters` (runtime) | Builder/config time only |
+
+### New APIs (Not in Photino)
+
+| API | Description |
+|-----|-------------|
+| `IInfiniFrameWindow.Focused` | Query/set keyboard focus |
+| `IInfiniFrameWindow.WaitForCloseAsync()` | Async close wait |
+| `IInfiniFrameWindow.ManagedThreadId` | Thread ID of message loop |
+| `IInfiniFrameWindow.InstanceHandle` / `NativeType` | Low-level native access |
+| `IInfiniFrameWindow.CachedPreFullScreenBounds` | Saved pre-fullscreen geometry |
+| `IInfiniFrameWindow.CachedPreMaximizedBounds` | Saved pre-maximized geometry |
+| `ZoomEnabled` | Separate bool for user zoom control |
+| `RegisterCustomSchemeHandler()` returns window | Fluent interface (was void) |
+| Configuration from `appsettings.json` | `"InfiniFrame"` section support |
+
+## Event System Migration
+
+### Photino: Last Assignment Wins
+
+```csharp
+// Photino — replacing handler
+window.RegisterWindowClosingHandler((sender, args) => { ... });
+window.RegisterWindowClosingHandler((sender, args) => { ... }); // REPLACES previous one
+```
+
+### InfiniFrame: Ordered Multi-Subscriber
+
+```csharp
+// InfiniFrame — both handlers run in order
+window.Events.WindowClosing.Add((window, args) => { ... });
+window.Events.WindowClosing.Add((window, args) => { ... }); // Also runs
+```
+
+### Closing Event Split
+
+| Photino | InfiniFrame | Purpose |
+|---------|-------------|---------|
+| `RegisterWindowClosingHandler` | `WindowClosingRequested` | Can cancel close (return true to allow) |
+| — | `WindowClosing` | Cannot cancel, runs when closing is definite |
+
+```csharp
+// Cancel close if unsaved changes
+builder.Events.WindowClosingRequested.Add(() => {
+    return HasUnsavedChanges() ? AskUserToConfirm() : true;
+});
+
+// Cleanup before close (cannot cancel)
+builder.Events.WindowClosing.Add((window, cancel) => {
+    SaveAppState();
+});
+```
+
+### DI-Resolved Event Handlers
+
+```csharp
+window.Events.WindowClosing.Add((MyService svc, IInfiniFrameWindow w) => {
+    svc.Cleanup();
+});
+```
+
+Requires `IServiceProvider` passed to `Build()`.
+
+## Web Messaging Protocol Upgrade
+
+### Photino: Raw String Passthrough
+
+```csharp
+// Photino — single raw handler
+window.RegisterWebMessageReceivedHandler((sender, message) => {
+    // message is the full raw string from JS
+});
+```
+
+### InfiniFrame: Versioned JSON Envelope
+
+```json
+{ "id": "event:name", "data": <any>, "version": 1 }
+```
+
+```csharp
+// InfiniFrame — named handler with typed payload
+window.MessageHandlers.RegisterMessageHandler("event:name", (window, payload) => {
+    // payload is the "data" field from the envelope
+});
+```
+
+```js
+// JavaScript MUST use envelope format
+window.infiniframe.host.postMessage({ id: "event:name", data: { value: 42 }, version: 1 });
+```
+
+**Legacy `messageId;payload` format is out of support.**
+
+## Logging System Replacement
+
+### Photino (Removed)
+
+```csharp
+window.SetLogVerbosity(2); // 0 = silent, higher = more verbose
+// Bug: even verbosity 0 logged a message
+```
+
+### InfiniFrame: ILogger Integration
+
+```csharp
+var services = new ServiceCollection();
+services.AddLogging(builder => {
+    builder.AddConsole();
+    builder.SetMinimumLevel(LogLevel.Debug);
+});
+var serviceProvider = services.BuildServiceProvider();
+
+var window = InfiniFrameWindowBuilder.Create()
+    .Build(serviceProvider); // ILogger<IInfiniFrameWindow> resolved from DI
+```
+
+## Native C++ Interface Changes
+
+### P/Invoke Signature Update
+
+```csharp
+// Photino — manual DllImport
+[DllImport("Photino.Native", ...)]
+static extern void Photino_SetTitle(IntPtr instance, string title);
+
+// InfiniFrame — source-generated LibraryImport
+[LibraryImport("InfiniFrame.Native", ...)]
+static partial void InfiniFrame_SetTitle(IntPtr instance, ...);
+```
+
+### String Ownership
+
+```csharp
+// If calling native exports directly, you MUST free returned strings
+IntPtr titlePtr = InfiniFrame_GetTitle(windowHandle);
+string title = Marshal.PtrToStringAnsi(titlePtr);
+InfiniFrame_FreeString(titlePtr);  // MANDATORY — prevents memory leaks
+```
+
+### SaveFileDialog Signature Change
+
+```csharp
+// Photino
+Photino_ShowSaveFile(title, defaultPath, filters, count)
+
+// InfiniFrame — added defaultFileName parameter
+InfiniFrame_ShowSaveFile(title, defaultPath, filters, count, defaultFileName)
+```
+
+## Known Photino Issues Fixed in InfiniFrame
+
+| Photino Issue | Description | How Fixed |
+|---------------|-------------|-----------|
+| [photino.native #173/174](https://github.com/tryphotino/photino.native/issues/173) | Custom scheme handlers broken on Windows | Rewritten registration path |
+| [photino.native #165](https://github.com/tryphotino/photino.native/issues/165) | Memory leak in `SendWebMessage` | Explicit `InfiniFrame_FreeString` ownership |
+| [photino.native #158](https://github.com/tryphotino/photino.native/issues/158) | No programmatic window focus | `InfiniFrame_SetFocused` / `GetFocused` exported |
+| [photino.native #163](https://github.com/tryphotino/photino.native/issues/163) | UTF encoding bug corrupts non-ASCII paths | `simdutf` for all conversions |
+| [photino.native #141](https://github.com/tryphotino/photino.native/issues/141) | Stack overflow in `WaitForExit` on Linux | Per-window independent message loops |
+| [photino.NET #75](https://github.com/tryphotino/photino.NET/issues/75) | `RegisterWindowClosingHandler` doesn't fire on Linux | GTK `delete-event` signal correctly used |
+| [photino.NET #257](https://github.com/tryphotino/photino.NET/issues/257) | `SetLogVerbosity(0)` still logs | Integer verbosity removed entirely |
+| [photino.NET #232](https://github.com/tryphotino/photino.NET/issues/232) | Custom scheme handlers break `fetch`/`XHR` | CORS headers handled correctly |
+| [photino.native #175](https://github.com/tryphotino/photino.native/issues/175) | `SetTopmost` wrong Win32 style, null crash on Linux | Fixed `HWND_TOPMOST`/`HWND_NOTOPMOST` |
+
+## Step-by-Step Migration Checklist
+
+1. **Update package references**: `Photino.NET` → `InfiniLore.InfiniFrame`
+2. **Update namespaces**: `using Photino.NET;` → `using InfiniFrame;`
+3. **Replace construction**: `new PhotinoWindow()` → `InfiniFrameWindowBuilder.Create()`
+4. **Move configuration**: All config before `Build()`
+5. **Update events**: `RegisterWindowClosingHandler` → `Events.WindowClosingRequested.Add()`
+6. **Update messaging**: Raw handler → named handlers + JSON envelope
+7. **Replace logging**: `SetLogVerbosity` → `ILogger` via DI
+8. **Update P/Invoke**: `Photino_*` → `InfiniFrame_*`, `Photino.Native` → `InfiniFrame.Native`
+9. **Consolidate size APIs**: `SetMinHeight/Width` → `SetMinSize(w, h)`
+10. **Update dialog enums**: `PhotinoDialog*` → `InfiniFrameDialog*`
+11. **Add bootstrap** (if packaging): `InfiniFrameSingleFileBootstrap.Initialize()`
+12. **Verify STA**: `[STAThread]` on `Main()` for Windows
+
+## Common Patterns
+
+### Minimal Migration
+
+```csharp
+// BEFORE (Photino)
+var window = new PhotinoWindow()
+    .SetTitle("My App")
+    .SetSize(1280, 720)
+    .Load(new Uri("https://example.com"));
+window.WaitForClose();
+
+// AFTER (InfiniFrame)
+var window = InfiniFrameWindowBuilder.Create()
+    .SetTitle("My App")
+    .SetSize(1280, 720)
+    .SetStartUrl("https://example.com")
+    .Build();
+window.WaitForClose();
+```
+
+### Event Handler Migration
+
+```csharp
+// BEFORE (Photino)
+window.RegisterWindowClosingHandler((sender, args) => {
+    if (unsaved) args.Cancel = true;
+});
+
+// AFTER (InfiniFrame)
+builder.Events.WindowClosingRequested.Add(() => {
+    return unsaved ? false : true; // false cancels close
+});
+```
+
+### Messaging Migration
+
+```csharp
+// BEFORE (Photino)
+window.RegisterWebMessageReceivedHandler((sender, message) => {
+    if (message == "ping") window.SendWebMessage("pong");
+});
+
+// AFTER (InfiniFrame)
+builder.MessageHandlers.RegisterMessageHandler("ping", (window, _) => {
+    window.SendWebMessage(JsonSerializer.Serialize(new {
+        id = "pong",
+        data = null,
+        version = 1
+    }));
+});
+```
+
+```js
+// JavaScript MUST change from:
+window.chrome.webview.postMessage("ping;payload");  // WRONG — out of support
+
+// To:
+window.infiniframe.host.postMessage({ id: "ping", data: "payload", version: 1 });
+```
+
+## Anti-Patterns
+
+❌ **Keep Photino construction pattern**:
+```csharp
+// WRONG — Photino API doesn't exist in InfiniFrame
+var window = new PhotinoWindow().SetTitle("My App");
+```
+
+✅ **Use builder pattern**:
+```csharp
+var window = InfiniFrameWindowBuilder.Create().SetTitle("My App").Build();
+```
+
+❌ **Configure after Build**:
+```csharp
+var window = builder.Build();
+window.SetTitle("New Title");  // WRONG — SetTitle is builder-only
+```
+
+✅ **Configure before Build, use runtime API after**:
+```csharp
+var window = builder.SetTitle("My App").Build();
+window.Load("https://new-url.com");  // Runtime API
+```
+
+❌ **Use legacy messaging format**:
+```js
+window.chrome.webview.postMessage("id;payload");  // WRONG — out of support
+```
+
+✅ **Use versioned envelope**:
+```js
+window.infiniframe.host.postMessage({ id: "id", data: "payload", version: 1 });
+```
+
+❌ **Use SetLogVerbosity**:
+```csharp
+window.SetLogVerbosity(2);  // WRONG — removed
+```
+
+✅ **Use ILogger**:
+```csharp
+services.AddLogging(builder => builder.AddConsole());
+var window = builder.Build(serviceProvider);
+```

--- a/skills/infiniframe-web-server/SKILL.md
+++ b/skills/infiniframe-web-server/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: infiniframe-web-server
+description: Hosting ASP.NET Core applications with native windows using InfiniLore.InfiniFrame.WebServer. Blazor Server, SignalR, and graceful shutdown patterns.
+---
+# InfiniFrame Web Server (ASP.NET Core)
+
+> Skill for hosting ASP.NET Core applications with native windows using `InfiniLore.InfiniFrame.WebServer`.
+
+## When to Use This Skill
+
+- Running ASP.NET Core apps with native window frontend
+- Blazor Server applications
+- SignalR real-time applications
+- Applications requiring full ASP.NET Core pipeline (middleware, controllers, etc.)
+- Apps that need both server and native window
+
+## Package
+
+```bash
+dotnet add package InfiniLore.InfiniFrame.WebServer
+```
+
+## How It Works
+
+- ASP.NET Core server starts on **background thread**
+- Native window opens and navigates to server URL
+- Both shut down together when window closes (with `UseAutoServerClose()`)
+- Full ASP.NET Core pipeline available (middleware, controllers, SignalR, minimal APIs, Blazor Server)
+
+## Minimal Setup
+
+```csharp
+using InfiniFrame.WebServer;
+
+var app = InfiniFrameWebApplication.CreateBuilder(args)
+    .Build()
+    .UseAutoServerClose();
+
+app.WebApp.MapGet("/", () => "Hello from InfiniFrame");
+
+app.Run();  // Starts server, opens window, blocks until window closes
+```
+
+## Builder API
+
+`InfiniFrameWebApplication.CreateBuilder(args)` returns `InfiniFrameWebApplicationBuilder`:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `WebApp` | `WebApplicationBuilder` | Standard ASP.NET Core builder |
+| `Window` | `InfiniFrameWindowBuilder` | Fluent window configuration |
+
+### Configuring Window and Server
+
+```csharp
+var builder = InfiniFrameWebApplication.CreateBuilder(args);
+
+// Configure window
+builder.Window
+    .SetTitle("My Desktop App")
+    .SetSize(1280, 720)
+    .Center()
+    .SetDevToolsEnabled(true);
+
+// Configure ASP.NET Core
+builder.WebApp.Services.AddControllers();
+builder.WebApp.Services.AddSignalR();
+builder.WebApp.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+var app = builder.Build().UseAutoServerClose();
+
+app.WebApp.MapControllers();
+app.WebApp.MapHub<MyHub>("/hub");
+app.WebApp.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();
+```
+
+## Start URL Configuration
+
+URL resolved from configuration in this priority order:
+
+1. `ASPNETCORE_URLS` environment variable
+2. `urls` configuration key (appsettings.json)
+3. Manual override via `builder.Window.SetStartUrl(...)`
+
+### appsettings.json
+
+```json
+{
+  "urls": "http://localhost:5200"
+}
+```
+
+**Multiple URLs**: If multiple URLs configured, first one used as window's start URL:
+```json
+{
+  "urls": "http://localhost:5200;https://localhost:7200"
+}
+```
+Window opens with `http://localhost:5200`.
+
+## Accessing Window from ASP.NET Core
+
+`IInfiniFrameWindow` and `IInfiniFrameWindowBuilder` registered in DI container:
+
+### Minimal API
+
+```csharp
+app.WebApp.MapGet("/close", (IInfiniFrameWindow window) => {
+    window.Close();
+    return Results.Ok();
+});
+```
+
+### Controllers
+
+```csharp
+public class WindowController(IInfiniFrameWindow window) : ControllerBase {
+    [HttpGet("api/window/minimize")]
+    public IActionResult Minimize() {
+        window.Invoke(() => { 
+            // Minimize logic on UI thread
+        });
+        return Ok();
+    }
+}
+```
+
+### SignalR Hubs
+
+```csharp
+public class MyHub : Hub {
+    private readonly IInfiniFrameWindow _window;
+    
+    public MyHub(IInfiniFrameWindow window) {
+        _window = window;
+    }
+    
+    public async Task CloseApp() {
+        _window.Invoke(() => _window.Close());
+    }
+}
+```
+
+**Critical**: Window operations from ASP.NET Core handlers MUST use `window.Invoke()` to marshal to window thread.
+
+## Graceful Shutdown
+
+### UseAutoServerClose (Recommended)
+
+```csharp
+var app = builder.Build().UseAutoServerClose();
+```
+
+Automatically stops web server when window closed or close requested. Internally registers handlers on `WindowClosing` and `WindowClosingRequested` that call `WebApp.StopAsync()` in background task — UI thread never blocked.
+
+### Manual Shutdown
+
+```csharp
+// Stop both server and window
+app.Stop();
+
+// Stop server only
+await app.WebApp.StopAsync();
+
+// Then close window
+app.Window.Close();
+```
+
+## Blazor Server Example
+
+```csharp
+using InfiniFrame.WebServer;
+
+var builder = InfiniFrameWebApplication.CreateBuilder(args);
+
+builder.Window
+    .SetTitle("Blazor Server App")
+    .SetSize(1280, 720)
+    .Center();
+
+builder.WebApp.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+var app = builder.Build().UseAutoServerClose();
+
+app.WebApp.UseStaticFiles();
+app.WebApp.UseAntiforgery();
+app.WebApp.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();
+```
+
+## Static Web Assets
+
+`UseStaticWebAssets()` called automatically during builder initialization — static files from Razor class libraries served correctly.
+
+`UseDefaultFiles()` also applied during `Build()` — requests to `/` serve `wwwroot/index.html` if it exists.
+
+## Thread Model
+
+| Thread | Runs |
+|--------|------|
+| **Main thread** | Native window (UI thread) — MUST be STA on Windows |
+| **Background thread** | ASP.NET Core / Kestrel |
+
+### Thread Affinity Rules
+
+**From ASP.NET Core handlers → Window**:
+```csharp
+// MUST use Invoke
+window.Invoke(() => window.Close());
+```
+
+**From window event handlers → ASP.NET Core**:
+```csharp
+// Can call directly — ASP.NET Core is thread-safe
+await app.WebApp.StopAsync();
+```
+
+## Common Patterns
+
+### Minimal API with Controllers
+
+```csharp
+var builder = InfiniFrameWebApplication.CreateBuilder(args);
+
+builder.Window.SetTitle("API App").SetSize(1024, 768);
+
+builder.WebApp.Services.AddControllers();
+builder.WebApp.Services.AddEndpointsApiExplorer();
+builder.WebApp.Services.AddSwaggerGen();
+
+var app = builder.Build().UseAutoServerClose();
+
+app.WebApp.MapControllers();
+app.WebApp.MapGet("/", () => Results.Redirect("/swagger"));
+
+app.Run();
+```
+
+### SignalR Real-Time App
+
+```csharp
+var builder = InfiniFrameWebApplication.CreateBuilder(args);
+
+builder.WebApp.Services.AddSignalR();
+
+var app = builder.Build().UseAutoServerClose();
+
+app.WebApp.MapHub<ChatHub>("/chat");
+app.WebApp.UseStaticFiles();
+
+app.Run();
+```
+
+### Custom Port Configuration
+
+```csharp
+// Via code
+builder.WebApp.WebHost.ConfigureKestrel(options => {
+    options.ListenLocalhost(5000);
+});
+
+// Or via configuration
+builder.WebApp.Configuration["urls"] = "http://localhost:5000";
+```
+
+## Anti-Patterns
+
+❌ **Forget UseAutoServerClose**:
+```csharp
+// WRONG — server keeps running after window closes
+var app = builder.Build();
+```
+
+✅ **Always use UseAutoServerClose**:
+```csharp
+var app = builder.Build().UseAutoServerClose();
+```
+
+❌ **Call window ops directly from controller**:
+```csharp
+// WRONG — thread affinity violation
+[HttpGet("close")]
+public IActionResult Close(IInfiniFrameWindow window) {
+    window.Close();  // Called from Kestrel thread
+    return Ok();
+}
+```
+
+✅ **Use Invoke**:
+```csharp
+[HttpGet("close")]
+public IActionResult Close(IInfiniFrameWindow window) {
+    window.Invoke(() => window.Close());
+    return Ok();
+}
+```
+
+❌ **Use async Task Main**:
+```csharp
+// WRONG — STA ignored on Windows
+async Task Main(string[] args) { ... }
+```
+
+✅ **Use explicit Main with [STAThread]**:
+```csharp
+[STAThread]
+static void Main(string[] args) { ... }
+```
+
+## Examples
+
+- https://github.com/InfiniLore/InfiniFrame/tree/master/examples/InfiniFrameExample.WebApp.Blazor — Blazor Server with InteractiveServerComponents
+- https://github.com/InfiniLore/InfiniFrame/tree/master/examples/InfiniFrameExample.WebApp.React — React frontend with custom scheme handler and messaging
+- https://github.com/InfiniLore/InfiniFrame/tree/master/examples/InfiniFrameExample.WebApp.Vue — Vue.js frontend with all built-in JS message handlers


### PR DESCRIPTION
## Summary
Adds AI agent skills and specialist agents for InfiniFrame. Introduces `agents/` directory with specialist agents and `skills/` directory with technical skill documents containing detailed API references, patterns, and anti-patterns. All content uses web-only references (GitHub and [docs.infiniframe.dev](docs.infiniframe.dev))

> **Note:** The main reason I created this PR was to make it easier for AI developers to work with InfiniFrame. As the project is not yet very well known, AI agents do not always understand what to do with certain parts of the code and tend to follow the Photino patterns rather than the new ones introduced in InfiniFrame

## Type of Change
- [x] Documentation update

## Affected Modules / Scope

- [x] Other: `agents/`, `skills/` and the main `README.md`

## Changes Introduced
- Created `agents/` directory with 10 independent specialist agent files following dotnet-skills format
- Created `skills/` directory with 10 technical skill documents with detailed API guidance
- Added `Agents and Skills` section to the project `README.md`

## Related Issues

## Checklist

- [x] My code follows InfiniFrame's coding conventions
- [x] I added comments for complex or non-obvious code
- [x] Documentation updated (if applicable)
- [x] All tests pass locally
- [x] Added new tests for any new functionality
- [x] Existing tests pass
- [x] No new warnings or errors introduced
- [x] PR only includes changes relevant to the issue / feature

## 📖 Additional Context

### Structure Overview

**Agents** (`agents/`) - Independent AI specialist references:
- `infiniframe-window-specialist.md` - Native windows, events, threading, platform requirements
- `infiniframe-blazor-specialist.md` - Blazor WebView, DI, file providers, multi-window
- `infiniframe-webserver-specialist.md` - ASP.NET Core, Kestrel, SignalR, graceful shutdown
- `infiniframe-js-interop-specialist.md` - C#↔JS messaging, pointer capture, envelope protocol
- `infiniframe-chrome-specialist.md` - Chromeless windows, custom title bars, resize handles
- `infiniframe-packaging-specialist.md` - Single-file packaging, bootstrap, CI/CD
- `infiniframe-aot-trimming-specialist.md` - NativeAOT, trimming, warnings, CI validation
- `infiniframe-native-specialist.md` - Native C++ API, Pimpl, C ABI exports, P/Invoke
- `infiniframe-architect.md` - Architecture, DI patterns, migration from Photino in short
- `infiniframe-photino-migration-specialist` - Detailed Photino to InfiniFrame migration

**Skills** (`skills/`) - Technical knowledge base with code examples:
- `infiniframe-core-window-builder/` - Window builder API, configuration, dialogs, custom schemes
- `infiniframe-blazor-integration/` - Blazor lifecycle, project setup, components, services
- `infiniframe-web-server/` - ASP.NET Core hosting, Blazor Server, thread model
- `infiniframe-javascript-interop/` - Message handlers, structured data, InfiniFrame.Js
- `infiniframe-custom-window-chrome/` - Drag areas, resize thumbs, styling
- `infiniframe-packaging-tool/` - CLI usage, MSBuild integration, fallback policy
- `infiniframe-aot-trimminging-compatibility/` - Publish profiles, type rooting
- `infiniframe-native-cpp-api/` - Native architecture, exports, platform code
- `infiniframe-architecture-best-practices/` - Project structure, patterns, migration in short
- `infiniframe-photino-migration/` - Detailed breaking changes in Core/API and migration patterns

### Design Decisions
1. **Independent agents**: No cross-references between agent files
2. **Web-only references**: All links point to GitHub (`core` branch) or [docs.infiniframe.dev](docs.infiniframe.dev)
3. **Skills as subdirectories**: Each skill is a folder with `SKILL.md` for detailed technical content