### PR TITLE
Fix: Add null checks & safe freeing of entities

### DIFF
--- a/src/InfiniFrame.Native/Platform/Linux/Window.cpp
+++ b/src/InfiniFrame.Native/Platform/Linux/Window.cpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <X11/Xlib.h>
+#include <gio/gio.h>
 #include <webkit2/webkit2.h>
 #include <JavaScriptCore/JavaScript.h>
 #include <sstream>
@@ -124,6 +125,16 @@ static void HandleWebMessage(
 static void HandleCustomSchemeRequest(WebKitURISchemeRequest* request, const gpointer user_data) {
     WebResourceRequestedCallback webResourceRequestedCallback = reinterpret_cast<WebResourceRequestedCallback>(
         user_data);
+    if (webResourceRequestedCallback == nullptr) {
+        GError* error = g_error_new_literal(
+            G_IO_ERROR,
+            G_IO_ERROR_NOT_SUPPORTED,
+            "No custom scheme handler is registered.");
+        webkit_uri_scheme_request_finish_error(request, error);
+        g_error_free(error);
+        return;
+    }
+
     const gchar* uri = webkit_uri_scheme_request_get_uri(request);
     int numBytes = 0;
     AutoString contentType = nullptr;
@@ -284,6 +295,9 @@ void InfiniFrameWindow::Impl::set_webkit_customsettings(WebKitSettings* settings
 }
 
 void InfiniFrameWindow::Impl::AddCustomSchemeHandlers() {
+    if (_customSchemeCallback == nullptr)
+        return;
+
     WebKitWebContext* context = webkit_web_context_get_default();
     WebKitSecurityManager* securityManager = webkit_web_context_get_security_manager(context);
     for (const auto& value : _customSchemeNames) {

--- a/src/InfiniFrame.Native/Platform/Mac/UrlSchemeHandler.mm
+++ b/src/InfiniFrame.Native/Platform/Mac/UrlSchemeHandler.mm
@@ -9,7 +9,9 @@
     auto *urlUtf8 = const_cast<char *>([url.absoluteString UTF8String]);
     int numBytes = 0;
     char* contentType = nullptr;
-    void* dotNetResponse = requestHandler(urlUtf8, &numBytes, &contentType);
+    void* dotNetResponse = requestHandler == nullptr
+        ? nullptr
+        : requestHandler(urlUtf8, &numBytes, &contentType);
 
     NSInteger statusCode = dotNetResponse == nullptr ? 404 : 200;
     NSString* nsContentType = contentType == nullptr

--- a/src/InfiniFrame.Native/Platform/Mac/Window.mm
+++ b/src/InfiniFrame.Native/Platform/Mac/Window.mm
@@ -98,6 +98,9 @@ void InfiniFrameWindow::Impl::SetPreference(NSString *key, NSString *value)
 
 void InfiniFrameWindow::Impl::AddCustomScheme(const AutoStringConst scheme, WebResourceRequestedCallback requestHandler)
 {
+    if (requestHandler == nullptr)
+        return;
+
     UrlSchemeHandler* schemeHandler = [[[UrlSchemeHandler alloc] init] autorelease];
     schemeHandler->requestHandler = requestHandler;
 

--- a/src/InfiniFrame.Native/Platform/Windows/Dialog.cpp
+++ b/src/InfiniFrame.Native/Platform/Windows/Dialog.cpp
@@ -227,6 +227,8 @@ void AddFilters(
  * @return Heap-allocated array of UTF-16 paths, or null if nothing was selected
  */
 AutoString* GetResults(IFileOpenDialog* pfd, HRESULT* hr, int* resultCount) {
+    *resultCount = 0;
+
     IShellItemArray* psiResults = nullptr;
     *hr = pfd->GetResults(&psiResults);
     if (SUCCEEDED(*hr)) {
@@ -234,7 +236,7 @@ AutoString* GetResults(IFileOpenDialog* pfd, HRESULT* hr, int* resultCount) {
         psiResults->GetCount(&count);
         if (count > 0) {
             *resultCount = static_cast<int>(count);
-            auto** result = new wchar_t*[count];
+            auto** result = new wchar_t*[count]();
             for (DWORD i = 0; i < count; ++i) {
                 IShellItem* psiItem = nullptr;
                 *hr = psiResults->GetItemAt(i, &psiItem);


### PR DESCRIPTION
## Summary
Fixes two native crash hazards: null custom-scheme callbacks on Linux/macOS and unsafe freeing of uninitialized Windows dialog result entries

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Affected Modules / Scope
- [x] InfiniFrame.Native

## Changes Introduced
- Guard Linux and macOS custom-scheme handling against null `CustomSchemeHandler` callbacks
- Safely reject Linux custom-scheme requests when no native callback is registered
- Zero-initialize Windows dialog result arrays and reset `resultCount` before collecting results

## Related Issues
Closes #149
Closes #147

## Checklist
- [x] My code follows InfiniFrame's coding conventions
- [x] I added comments for complex or non-obvious code
- [x] Documentation updated (if applicable)
- [x] All tests pass locally
- [x] Existing tests pass
- [x] No new warnings or errors introduced
- [x] PR only includes changes relevant to issues

## Additional Context
Validation performed on origin CI: https://github.com/freakdaniel/InfiniFrame/actions/runs/24955896009