### PR TITLE
Potential fix for code scanning alert no. 1910: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -36,8 +36,11 @@ jobs:
         permissions:
             contents: read
         outputs:
+            actions: ${{ steps.filter.outputs.actions }}
             csharp: ${{ steps.filter.outputs.csharp }}
             cpp: ${{ steps.filter.outputs.cpp }}
+            javascript_typescript: ${{ steps.filter.outputs.javascript_typescript }}
+            python: ${{ steps.filter.outputs.python }}
         steps:
             -   name: Checkout
                 uses: actions/checkout@v6
@@ -49,11 +52,67 @@ jobs:
                 uses: dorny/paths-filter@v4
                 with:
                     filters: |
+                        actions:
+                          - '.github/workflows/**'
+                          - '.github/actions/**'
+                          - '.github/dependabot.yml'
+                          - '.github/codeql-config.yml'
                         csharp:
-                          - '**'
-                          - '!src/InfiniFrame.Native/**'
+                          - 'src/**/*.cs'
+                          - 'src/**/*.csproj'
+                          - 'src/**/*.props'
+                          - 'src/**/*.targets'
+                          - 'src/**/*.razor'
+                          - 'src/**/*.razor.css'
+                          - 'Directory.Packages.props'
+                          - 'global.json'
+                          - '.github/workflows/ci-codeql.yml'
+                          - '.github/codeql-config.yml'
                         cpp:
                           - 'src/InfiniFrame.Native/**'
+                          - 'native-vendor-deps.json'
+                          - 'global.json'
+                          - '.github/actions/setup-dependencies-native/**'
+                          - '.github/workflows/ci-codeql.yml'
+                          - '.github/codeql-config.yml'
+                        javascript_typescript:
+                          - 'src/**/*.js'
+                          - 'src/**/*.jsx'
+                          - 'src/**/*.ts'
+                          - 'src/**/*.tsx'
+                          - 'src/**/*.mjs'
+                          - 'src/**/*.cjs'
+                          - 'src/**/*.vue'
+                          - 'src/**/*.html'
+                          - 'src/**/package.json'
+                          - 'src/**/package-lock.json'
+                          - 'src/**/tsconfig*.json'
+                          - 'src/**/vite.config.*'
+                          - 'src/**/webpack.config.*'
+                          - 'src/**/eslint.config.*'
+                          - '.github/actions/**/*.js'
+                          - '.github/actions/**/*.ts'
+                          - '.github/workflows/ci-codeql.yml'
+                          - '.github/codeql-config.yml'
+                        python:
+                          - '.github/scripts/**/*.py'
+                          - '.github/scripts/**/*.pyi'
+                          - '.github/scripts/**/pyproject.toml'
+                          - '.github/scripts/**/requirements*.txt'
+                          - '.github/scripts/**/Pipfile'
+                          - '.github/scripts/**/Pipfile.lock'
+                          - '.github/scripts/**/tox.ini'
+                          - '.github/scripts/**/setup.cfg'
+                          - 'scripts/**/*.py'
+                          - 'scripts/**/*.pyi'
+                          - 'scripts/**/pyproject.toml'
+                          - 'scripts/**/requirements*.txt'
+                          - 'scripts/**/Pipfile'
+                          - 'scripts/**/Pipfile.lock'
+                          - 'scripts/**/tox.ini'
+                          - 'scripts/**/setup.cfg'
+                          - '.github/workflows/ci-codeql.yml'
+                          - '.github/codeql-config.yml'
 
     analyze:
         name: Analyze (${{ matrix.language }} on ${{ matrix.os }})
@@ -111,15 +170,20 @@ jobs:
                 env:
                     FULL_SCAN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.full_scan == 'true' }}
                     LANGUAGE: ${{ matrix.language }}
+                    ACTIONS_CHANGED: ${{ needs.changes.outputs.actions }}
                     CSHARP_CHANGED: ${{ needs.changes.outputs.csharp }}
                     CPP_CHANGED: ${{ needs.changes.outputs.cpp }}
+                    JAVASCRIPT_TYPESCRIPT_CHANGED: ${{ needs.changes.outputs.javascript_typescript }}
+                    PYTHON_CHANGED: ${{ needs.changes.outputs.python }}
                 run: |
                     should_run=false
 
                     if [[ "$FULL_SCAN" == "true" ]]; then should_run=true
+                    elif [[ "$LANGUAGE" == "actions" && "$ACTIONS_CHANGED" == "true" ]]; then should_run=true
                     elif [[ "$LANGUAGE" == "csharp" && "$CSHARP_CHANGED" == "true" ]]; then should_run=true
                     elif [[ "$LANGUAGE" == "c-cpp" && "$CPP_CHANGED" == "true" ]]; then should_run=true
-                    elif [[ "$LANGUAGE" != "csharp" && "$LANGUAGE" != "c-cpp" ]]; then should_run=true
+                    elif [[ "$LANGUAGE" == "javascript-typescript" && "$JAVASCRIPT_TYPESCRIPT_CHANGED" == "true" ]]; then should_run=true
+                    elif [[ "$LANGUAGE" == "python" && "$PYTHON_CHANGED" == "true" ]]; then should_run=true
                     fi
 
                     echo "run=$should_run" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -30,6 +30,9 @@ jobs:
     changes:
         name: Detect Changed Areas
         runs-on: ubuntu-latest
+        if: >
+            github.event_name != 'workflow_dispatch' ||
+            github.event.inputs.full_scan != 'true'
         permissions:
             contents: read
         outputs:
@@ -59,8 +62,16 @@ jobs:
         timeout-minutes: 90
 
         if: >
-            github.event_name != 'pull_request' ||
-            github.event.pull_request.draft == false
+            always() && (
+                needs.changes.result == 'success' 
+                || (
+                    github.event_name == 'workflow_dispatch' 
+                    && github.event.inputs.full_scan == 'true' 
+                    && needs.changes.result == 'skipped'
+            )) && (
+                github.event_name != 'pull_request' 
+                || github.event.pull_request.draft == false
+            )
 
         permissions:
             contents: read

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -30,9 +30,6 @@ jobs:
     changes:
         name: Detect Changed Areas
         runs-on: ubuntu-latest
-        if: >
-            github.event_name != 'workflow_dispatch' ||
-            github.event.inputs.full_scan != 'true'
         permissions:
             contents: read
         outputs:
@@ -62,15 +59,8 @@ jobs:
         timeout-minutes: 90
 
         if: >
-            (
-                github.event_name != 'pull_request' 
-                || github.event.pull_request.draft == false
-            ) && (
-                github.event_name == 'workflow_dispatch' && github.event.inputs.full_scan == 'true'
-                || matrix.language == 'csharp' && needs.changes.outputs.csharp == 'true'
-                || matrix.language == 'c-cpp' && needs.changes.outputs.cpp == 'true'
-                || matrix.language != 'csharp' && matrix.language != 'c-cpp'
-            )
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.draft == false
 
         permissions:
             contents: read
@@ -104,12 +94,33 @@ jobs:
                         build-mode: none
 
         steps:
+            -   name: Decide Whether to Analyze
+                id: should_analyze
+                shell: bash
+                env:
+                    FULL_SCAN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.full_scan == 'true' }}
+                    LANGUAGE: ${{ matrix.language }}
+                    CSHARP_CHANGED: ${{ needs.changes.outputs.csharp }}
+                    CPP_CHANGED: ${{ needs.changes.outputs.cpp }}
+                run: |
+                    should_run=false
+
+                    if [[ "$FULL_SCAN" == "true" ]]; then should_run=true
+                    elif [[ "$LANGUAGE" == "csharp" && "$CSHARP_CHANGED" == "true" ]]; then should_run=true
+                    elif [[ "$LANGUAGE" == "c-cpp" && "$CPP_CHANGED" == "true" ]]; then should_run=true
+                    elif [[ "$LANGUAGE" != "csharp" && "$LANGUAGE" != "c-cpp" ]]; then should_run=true
+                    fi
+
+                    echo "run=$should_run" >> "$GITHUB_OUTPUT"
+
             -   name: Checkout
+                if: steps.should_analyze.outputs.run == 'true'
                 uses: actions/checkout@v6
                 with:
                     fetch-depth: 1
 
             -   name: Setup .NET
+                if: steps.should_analyze.outputs.run == 'true'
                 uses: actions/setup-dotnet@v5
                 with:
                     dotnet-version: |
@@ -118,11 +129,11 @@ jobs:
                         10.x
 
             -   name: Setup CMake
-                if: matrix.language == 'c-cpp'
+                if: steps.should_analyze.outputs.run == 'true' && matrix.language == 'c-cpp'
                 uses: lukka/get-cmake@latest
 
             -   name: Setup Native dependencies
-                if: matrix.language == 'c-cpp'
+                if: steps.should_analyze.outputs.run == 'true' && matrix.language == 'c-cpp'
                 uses: ./.github/actions/setup-dependencies-native
                 # noinspection UndefinedParamsPresent
                 with:
@@ -131,6 +142,7 @@ jobs:
                     brew-restore-key: ${{ runner.os }}-${{ matrix.language }}-brew-native-
 
             -   name: Initialize CodeQL
+                if: steps.should_analyze.outputs.run == 'true'
                 uses: github/codeql-action/init@v4
                 with:
                     languages: ${{ matrix.language }}
@@ -139,22 +151,23 @@ jobs:
                     config-file: ./.github/codeql-config.yml
 
             -   name: Restore C# (.slnx)
-                if: matrix.language == 'csharp' && matrix.build-mode == 'manual'
+                if: steps.should_analyze.outputs.run == 'true' && matrix.language == 'csharp' && matrix.build-mode == 'manual'
                 run: |
                     dotnet restore InfiniFrame.slnx /p:NoWarn=NU1503
 
             -   name: Build Native (CodeQL)
-                if: matrix.language == 'c-cpp'
+                if: steps.should_analyze.outputs.run == 'true' && matrix.language == 'c-cpp'
                 shell: pwsh
                 run: |
                     dotnet build src/InfiniFrame.Native/InfiniFrame.Native.proj --configuration Release --no-restore -p:SolutionDir="${{ github.workspace }}/" -p:Platform=x64
 
             -   name: Build C# (.slnx)
-                if: matrix.language == 'csharp' && matrix.build-mode == 'manual'
+                if: steps.should_analyze.outputs.run == 'true' && matrix.language == 'csharp' && matrix.build-mode == 'manual'
                 run: |
                     dotnet build InfiniFrame.slnx --no-restore --configuration Release -p:InfiniFramePackAfterBuild=false
 
             -   name: Perform CodeQL Analysis
+                if: steps.should_analyze.outputs.run == 'true'
                 uses: github/codeql-action/analyze@v4
                 with:
                     category: "/language:${{ matrix.language }}"

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -16,11 +16,23 @@ on:
             - '.github/ISSUE_TEMPLATE/**'
             - '.github/*.md'
     workflow_dispatch:
+        inputs:
+            full_scan:
+                description: "Run full CodeQL scan (ignore path filters)"
+                required: false
+                default: "false"
+                type: choice
+                options:
+                    - "false"
+                    - "true"
 
 jobs:
     changes:
         name: Detect Changed Areas
         runs-on: ubuntu-latest
+        if: >
+            github.event_name != 'workflow_dispatch' ||
+            github.event.inputs.full_scan != 'true'
         permissions:
             contents: read
         outputs:
@@ -30,7 +42,7 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v6
                 with:
-                    fetch-depth: 0
+                    fetch-depth: 1
 
             -   name: Detect Changes
                 id: filter
@@ -90,15 +102,22 @@ jobs:
                 shell: pwsh
                 run: |
                     $run = 'false'
-                    if ("${{ matrix.language }}" -eq "csharp" -and "${{ needs.changes.outputs.csharp }}" -eq "true") {
+                    
+                    $isFullScan = "${{ github.event_name }}" -eq "workflow_dispatch" -and "${{ github.event.inputs.full_scan }}" -eq "true"
+                    
+                    if ($isFullScan) {
                       $run = 'true'
                     }
-                    elseif ("${{ matrix.language }}" -eq "c-cpp" -and "${{ needs.changes.outputs.cpp }}" -eq "true") {
+                    elseif ("${{ matrix.language }}" -eq "csharp" -and "${{ needs.changes.outputs.csharp || 'false' }}" -eq "true") {
+                      $run = 'true'
+                    }
+                    elseif ("${{ matrix.language }}" -eq "c-cpp" -and "${{ needs.changes.outputs.cpp || 'false' }}" -eq "true") {
                       $run = 'true'
                     }
                     elseif ("${{ matrix.language }}" -ne "csharp" -and "${{ matrix.language }}" -ne "c-cpp") {
                       $run = 'true'
                     }
+                    
                     "run=$run" >> $env:GITHUB_OUTPUT
 
             -   name: Checkout

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -42,7 +42,7 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v6
                 with:
-                    fetch-depth: 1
+                    fetch-depth: 0
 
             -   name: Detect Changes
                 id: filter
@@ -54,16 +54,23 @@ jobs:
                           - '!src/InfiniFrame.Native/**'
                         cpp:
                           - 'src/InfiniFrame.Native/**'
-    
+
     analyze:
         name: Analyze (${{ matrix.language }} on ${{ matrix.os }})
         needs: changes
         runs-on: ${{ matrix.os }}
         timeout-minutes: 90
-        
+
         if: >
-            github.event_name != 'pull_request' 
-            || github.event.pull_request.draft == false
+            (
+                github.event_name != 'pull_request' 
+                || github.event.pull_request.draft == false
+            ) && (
+                github.event_name == 'workflow_dispatch' && github.event.inputs.full_scan == 'true'
+                || matrix.language == 'csharp' && needs.changes.outputs.csharp == 'true'
+                || matrix.language == 'c-cpp' && needs.changes.outputs.cpp == 'true'
+                || matrix.language != 'csharp' && matrix.language != 'c-cpp'
+            )
 
         permissions:
             contents: read
@@ -72,7 +79,7 @@ jobs:
             packages: read
             pull-requests: write
             checks: write
-        
+
         strategy:
             fail-fast: false
             matrix:
@@ -95,39 +102,14 @@ jobs:
                     -   language: python
                         os: ubuntu-latest
                         build-mode: none
-        
-        steps:
-            -   name: Determine Matrix Run
-                id: gate
-                shell: pwsh
-                run: |
-                    $run = 'false'
-                    
-                    $isFullScan = "${{ github.event_name }}" -eq "workflow_dispatch" -and "${{ github.event.inputs.full_scan }}" -eq "true"
-                    
-                    if ($isFullScan) {
-                      $run = 'true'
-                    }
-                    elseif ("${{ matrix.language }}" -eq "csharp" -and "${{ needs.changes.outputs.csharp || 'false' }}" -eq "true") {
-                      $run = 'true'
-                    }
-                    elseif ("${{ matrix.language }}" -eq "c-cpp" -and "${{ needs.changes.outputs.cpp || 'false' }}" -eq "true") {
-                      $run = 'true'
-                    }
-                    elseif ("${{ matrix.language }}" -ne "csharp" -and "${{ matrix.language }}" -ne "c-cpp") {
-                      $run = 'true'
-                    }
-                    
-                    "run=$run" >> $env:GITHUB_OUTPUT
 
+        steps:
             -   name: Checkout
-                if: steps.gate.outputs.run == 'true'
                 uses: actions/checkout@v6
                 with:
                     fetch-depth: 1
 
             -   name: Setup .NET
-                if: steps.gate.outputs.run == 'true'
                 uses: actions/setup-dotnet@v5
                 with:
                     dotnet-version: |
@@ -136,12 +118,11 @@ jobs:
                         10.x
 
             -   name: Setup CMake
-                if: steps.gate.outputs.run == 'true' && matrix.language == 'c-cpp'
+                if: matrix.language == 'c-cpp'
                 uses: lukka/get-cmake@latest
 
             -   name: Setup Native dependencies
-                if: steps.gate.outputs.run == 'true' && matrix.language == 'c-cpp'
-                # noinspection UndefinedAction
+                if: matrix.language == 'c-cpp'
                 uses: ./.github/actions/setup-dependencies-native
                 # noinspection UndefinedParamsPresent
                 with:
@@ -150,7 +131,6 @@ jobs:
                     brew-restore-key: ${{ runner.os }}-${{ matrix.language }}-brew-native-
 
             -   name: Initialize CodeQL
-                if: steps.gate.outputs.run == 'true'
                 uses: github/codeql-action/init@v4
                 with:
                     languages: ${{ matrix.language }}
@@ -159,23 +139,22 @@ jobs:
                     config-file: ./.github/codeql-config.yml
 
             -   name: Restore C# (.slnx)
-                if: steps.gate.outputs.run == 'true' && matrix.language == 'csharp' && matrix.build-mode == 'manual'
+                if: matrix.language == 'csharp' && matrix.build-mode == 'manual'
                 run: |
                     dotnet restore InfiniFrame.slnx /p:NoWarn=NU1503
 
             -   name: Build Native (CodeQL)
-                if: steps.gate.outputs.run == 'true' && matrix.language == 'c-cpp'
+                if: matrix.language == 'c-cpp'
                 shell: pwsh
                 run: |
                     dotnet build src/InfiniFrame.Native/InfiniFrame.Native.proj --configuration Release --no-restore -p:SolutionDir="${{ github.workspace }}/" -p:Platform=x64
 
             -   name: Build C# (.slnx)
-                if: steps.gate.outputs.run == 'true' && matrix.language == 'csharp' && matrix.build-mode == 'manual'
+                if: matrix.language == 'csharp' && matrix.build-mode == 'manual'
                 run: |
                     dotnet build InfiniFrame.slnx --no-restore --configuration Release -p:InfiniFramePackAfterBuild=false
 
             -   name: Perform CodeQL Analysis
-                if: steps.gate.outputs.run == 'true'
                 uses: github/codeql-action/analyze@v4
                 with:
                     category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,8 @@ jobs:
     changes:
         name: Detect Changed Areas
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         outputs:
             csharp: ${{ steps.filter.outputs.csharp }}
             cpp: ${{ steps.filter.outputs.cpp }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,14 +50,16 @@ jobs:
         timeout-minutes: 90
         
         if: >
-            github.event_name != 'pull_request' ||
-            github.event.pull_request.draft == false
-        
+            github.event_name != 'pull_request' 
+            || github.event.pull_request.draft == false
+
         permissions:
-            security-events: write
-            packages: read
-            actions: read
             contents: read
+            security-events: write
+            actions: read
+            packages: read
+            pull-requests: write
+            checks: write
         
         strategy:
             fail-fast: false

--- a/InfiniFrame.slnx
+++ b/InfiniFrame.slnx
@@ -61,7 +61,7 @@
     <File Path=".github/workflows/ci-release.yml" />
     <File Path=".github/workflows/ci-testing-python.yml" />
     <File Path=".github/workflows/ci-todo.yml" />
-    <File Path=".github/workflows/codeql.yml" />
+    <File Path=".github/workflows/ci-codeql.yml" />
   </Folder>
   <Folder Name="/.dev-tools/github/actions/">
     <File Path=".github/actions/validate-native-test-binaries/action.yml" />


### PR DESCRIPTION
Potential fix for [https://github.com/InfiniLore/InfiniFrame/security/code-scanning/1910](https://github.com/InfiniLore/InfiniFrame/security/code-scanning/1910)

Add an explicit `permissions` block to the `changes` job with the minimum required scope.  
Best fix without changing functionality: set `contents: read` under `jobs.changes`, since the job only checks out code and evaluates changed paths. This satisfies CodeQL and preserves current behavior while preventing broader inherited token rights.

Edit only `.github/workflows/codeql.yml`, in the `changes` job section (around lines 22–24), by inserting:

```yml
permissions:
    contents: read
```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
